### PR TITLE
feat: persist grid / list view mode in localStorage

### DIFF
--- a/frontend/src/pages/VMsPage.tsx
+++ b/frontend/src/pages/VMsPage.tsx
@@ -402,7 +402,14 @@ function GroupSection({ group, vms, view, onEditVM, collapsed, onToggle, cpuSpee
 export default function VMsPage() {
   const qc = useQueryClient()
   const { addToast, authConfig, serverOnline, openTabs, updateTabGroupColor } = useStore()
-  const [view, setView] = useState<ViewMode>('grid')
+  const [view, setView] = useState<ViewMode>(() => {
+    const savedMode = localStorage.getItem('vmViewPreference');
+    return (savedMode === 'grid' || savedMode === 'list') ? savedMode : 'grid';
+  });
+
+  useEffect(() => {
+    localStorage.setItem('vmViewPreference', view);
+  }, [view]);
   const [showCreateVM, setShowCreateVM] = useState(false)
   const [editVM, setEditVM] = useState<VM | null>(null)
   const [showCreateGroup, setShowCreateGroup] = useState(false)


### PR DESCRIPTION
Hi David! This small PR saves the user's preference for the Grid / List view in the VMs page to the browser's localStorage (fixes #5). This way, the layout persists across page reloads and logins. Tested locally and it works fine. Cheers!