### PR TITLE
fix: refresh hardware db

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -103,7 +103,7 @@ async def _refresh_hardware_db():
     else:
         log.info("Hardware database not in config — will download and generate now.")
 
-    result = await refresh_hardware_json(config_dir, cache_dir)
+    result = await refresh_hardware_json(config_dir, cache_dir=cache_dir)
     if result:
         log.info("Hardware database ready: %s", result)
     else:

--- a/backend/app/routers/system.py
+++ b/backend/app/routers/system.py
@@ -243,7 +243,8 @@ async def refresh_hardware_lists(current_user: User = Depends(require_admin)):
     from ..services.machine_db import refresh_hardware_json
 
     config_dir = Path(settings.data_path) / "config"
-    result = await refresh_hardware_json(config_dir, force=True)
+    cache_dir = Path(settings.data_path) / "cache"
+    result = await refresh_hardware_json(config_dir, cache_dir=cache_dir, force=True)
     if not result:
         raise HTTPException(500, "Hardware database refresh failed — check server logs.")
     # Reload the hardware lists module so the new data is used immediately


### PR DESCRIPTION
Hi! I noticed that the manual hardware refresh button was triggering a 500 Internal Server Error, while the automatic background task was working fine.

What this PR does:
- Backend: Added the missing cache_dir argument and variable definition to refresh_hardware_json inside routers/system.py. (I also explicitly named the argument in main.py for consistency).

Tested locally and on my Unraid server. Works perfectly now!

<img width="474" height="128" alt="Screenshot" src="https://github.com/user-attachments/assets/1ab78dc0-9876-4d41-bad6-255fd548afe5" />


(Fixes #2)