### PR TITLE
fix: Use string names instead of legacy numeric IDs for CD-ROM drives

### DIFF
--- a/backend/app/routers/vms.py
+++ b/backend/app/routers/vms.py
@@ -502,16 +502,7 @@ def _write_86box_config(vm: VM, vm_dir: str, config_override: dict | None = None
     config_override: optional key/value pairs merged into cfg at write time
     (not persisted to DB). Used e.g. to inject PCap transport for group networking.
     """
-    from ..hardware_lists import get_cpu_by_index, machine_has_builtin_video, get_cdrom_drive_types
-    _cdrom_drive_list = get_cdrom_drive_types()
-    def _cdrom_type_index(internal_name: str) -> int | None:
-        """Map a cdrom_drive_type internal_name to its numeric 86Box index."""
-        if not internal_name:
-            return None
-        for idx, d in enumerate(_cdrom_drive_list):
-            if d.get("internal_name") == internal_name:
-                return idx
-        return None
+    from ..hardware_lists import get_cpu_by_index, machine_has_builtin_video
 
     cfg = dict(vm.config or {})
     if config_override:
@@ -698,9 +689,9 @@ def _write_86box_config(vm: VM, vm_dir: str, config_override: dict | None = None
             speed = cfg.get(f"cdrom_{n}_speed", 24)
             if speed != 24:
                 opt(f"cdrom_{n}_speed", speed)
-            drive_type_idx = _cdrom_type_index(cfg.get(f"cdrom_{n}_drive_type", ""))
-            if drive_type_idx is not None:
-                opt(f"cdrom_{n}_type", drive_type_idx)
+            drive_type = cfg.get(f"cdrom_{n}_drive_type", "")
+            if drive_type:
+                opt(f"cdrom_{n}_type", drive_type)
             if bus_str == "atapi":
                 channel = cfg.get(f"cdrom_{n}_ide_channel") or _default_cdrom_channels[i]
                 opt(f"cdrom_{n}_ide_channel", channel)


### PR DESCRIPTION
When starting a VM with a CD-ROM drive, 86Box throws a 'CD-ROM x (ID) not found - contact 86Box support' warning and fails to mount the drive.

How I found the solution to the issue:
I compared a manually created 86Box.cfg file with the one generated by 86web. I noticed that my manual config only used string names (like 86BOX_CD-ROM_1.00) for the drives, while 86web was writing numeric IDs. This led me to the assumption that modern 86Box versions can't handle these legacy IDs anymore.

The fix:
I discovered that vms.py was still using a conversion function (_cdrom_type_index) to translate the modern internal_name strings back into old numeric indices before writing them to the config. I completely removed this obsolete translation procedure and updated the code to write the internal_name directly to cdrom_01_type.

Tested on my Unraid server: The warning is gone and the CD-ROM drive is properly recognized on initial boot and is also properly written in the 86Box.cfg file.

(Fixes #3)