### PR TITLE
fix: Resolve missing directory paths for CD-ROM and Floppy media

### DIFF
--- a/backend/app/routers/vms.py
+++ b/backend/app/routers/vms.py
@@ -530,6 +530,12 @@ def _write_86box_config(vm: VM, vm_dir: str, config_override: dict | None = None
         if isinstance(v, float) and v == int(v):
             return str(int(v))
         return str(v)
+    def _resolve_media(fn: str) -> str:
+        if not fn:
+            return ""
+        if os.path.isabs(fn):
+            return fn
+        return os.path.join(vm_dir, fn)
 
     # ── [Machine] ──────────────────────────────────────────────────────────────
     section("Machine")
@@ -685,7 +691,7 @@ def _write_86box_config(vm: VM, vm_dir: str, config_override: dict | None = None
             opt(f"fdd_{n}_check_bpb", 0)
         fn = cfg.get(f"fdd_{n}_fn", "")
         if fn and ftype != "none":
-            opt(f"fdd_{n}_fn", fn)
+            opt(f"fdd_{n}_fn", _resolve_media(fn))
 
     # CD-ROM drives 01-04
     _default_cdrom_channels = {1: "1:0", 2: "1:1", 3: "2:0", 4: "2:1"}
@@ -706,7 +712,7 @@ def _write_86box_config(vm: VM, vm_dir: str, config_override: dict | None = None
                 opt(f"cdrom_{n}_ide_channel", channel)
             fn = cfg.get(f"cdrom_{n}_fn", "")
             if fn:
-                opt(f"cdrom_{n}_image_path", fn)
+                opt(f"cdrom_{n}_image_path", _resolve_media(fn))
 
     # ── [Ports (COM & LPT)] ───────────────────────────────────────────────────
     section("Ports (COM & LPT)")

--- a/frontend/src/components/ImagePickerModal.tsx
+++ b/frontend/src/components/ImagePickerModal.tsx
@@ -546,7 +546,8 @@ export default function ImagePickerModal({ kind, currentPath, onSelect, onClear,
               <WritableColumnBrowser
                 tree={imagesTree}
                 kind={kind}
-                onSelect={onSelect ? (node, path) => { onSelect(path); onClose() } : undefined}
+                // FIX: Prepend the correct VM media subdirectory
+                onSelect={onSelect ? (node, path) => { onSelect(`media/images/${path}`); onClose() } : undefined}
               />
             )
           )}
@@ -560,7 +561,8 @@ export default function ImagePickerModal({ kind, currentPath, onSelect, onClear,
               <ColumnBrowser
                 tree={libraryTree}
                 kind={kind}
-                onSelect={onSelect ? (node, path) => { onSelect(path); onClose() } : undefined}
+                // FIX: Prepend the correct VM media subdirectory
+                onSelect={onSelect ? (node, path) => { onSelect(`media/library/${path}`); onClose() } : undefined}
               />
             )
           )}


### PR DESCRIPTION
**Issue:**
When selecting a CD-ROM (ISO) or Floppy image via the Media Viewer in the VM settings, 86Box would fail to mount the image on startup. The emulator threw an error because it was looking for the file directly in the VM's root directory (e.g., /data/vms/[uuid]/image.iso).

The root cause was that the ImagePickerModal was only returning the base filename (or relative sub-path) without the leading media/library/ or media/images/ directories. The backend then wrote this incomplete path into 86box.cfg.

**Solution:**
This PR implements a clean, deterministic fix across both the frontend and backend to ensure strict path resolution:

Frontend (_ImagePickerModal.tsx_): Updated the onSelect callbacks in both the 'My Images' and 'Library' tabs. The picker now explicitly prepends the correct relative subdirectory (media/images/ or media/library/) before saving it to the VM config state.

Backend (_vms.py_): Added a strict _resolve_media helper. Instead of guessing or searching the disk, the backend now completely trusts the frontend's provided path and safely anchors it to the vm_dir to generate a proper absolute path for 86Box. Applied this to both FDD and CD-ROM config generation.

Note: This fixes the startup mounting issues. (Fixes #11)