### PR TITLE
Feat: Import existing / unregistered 86Box VMs

### DIFF
--- a/backend/app/routers/import_vms.py
+++ b/backend/app/routers/import_vms.py
@@ -1,0 +1,165 @@
+import os
+import configparser
+from pydantic import BaseModel
+
+class VMImportRequest(BaseModel):
+    folder_name: str
+    vm_name: str
+    description: str = ""
+    group_id: int | None = None
+
+def scan_for_unregistered_folders(vms_path: str, db_uuids: set) -> list:
+    """Scans the vms_path for directories containing an 86box.cfg that are not registered in the DB."""
+    unregistered = []
+    if os.path.exists(vms_path):
+        for folder_name in os.listdir(vms_path):
+            folder_path = os.path.join(vms_path, folder_name)
+            
+            # Check if it's a directory and not already registered by its folder name (which should be the UUID)
+            if os.path.isdir(folder_path) and folder_name not in db_uuids:
+                cfg_path = os.path.join(folder_path, "86box.cfg")
+                if os.path.exists(cfg_path):
+                    machine_name = "Unknown Machine"
+                    try:
+                        cfg = configparser.RawConfigParser()
+                        cfg.read(cfg_path, encoding="utf-8-sig")
+                        if cfg.has_option("Machine", "machine"):
+                            machine_name = cfg.get("Machine", "machine")
+                    except Exception:
+                        pass
+                        
+                    unregistered.append({
+                        "folder_name": folder_name,
+                        "machine": machine_name
+                    })
+    return unregistered
+
+# --- Helper functions for safe type parsing ---
+
+def _get_int(cfg: configparser.RawConfigParser, section: str, key: str, default: int = 0) -> int:
+    try:
+        return int(cfg.get(section, key))
+    except Exception:
+        return default
+
+def _get_bool(cfg: configparser.RawConfigParser, section: str, key: str, default: bool = False) -> bool:
+    try:
+        val = cfg.get(section, key).strip().lower()
+        return val in ("1", "true", "yes", "on")
+    except Exception:
+        return default
+
+def _get_str(cfg: configparser.RawConfigParser, section: str, key: str, default: str = "") -> str:
+    try:
+        return cfg.get(section, key)
+    except Exception:
+        return default
+
+def parse_86box_cfg(cfg_path: str) -> dict:
+    """Reads an existing 86box.cfg and translates it into the JSON state format used by the React frontend."""
+    cfg = configparser.RawConfigParser()
+    cfg.read(cfg_path, encoding="utf-8-sig")
+    
+    parsed = {}
+    
+    # --- Machine settings ---
+    if cfg.has_section("Machine"):
+        parsed["machine"] = _get_str(cfg, "Machine", "machine", "ibm_pc")
+        parsed["mem_size"] = _get_int(cfg, "Machine", "mem_size", 64)
+        parsed["cpu_family"] = _get_str(cfg, "Machine", "cpu_family", "")
+        # NEW: Keep the raw Hz value temporarily to translate it into an index later
+        parsed["_raw_cpu_speed"] = _get_int(cfg, "Machine", "cpu_speed", 0)
+        parsed["cpu_use_dynarec"] = _get_bool(cfg, "Machine", "cpu_use_dynarec", True)
+        parsed["time_sync"] = _get_str(cfg, "Machine", "time_sync", "local")
+        parsed["fpu_type"] = _get_str(cfg, "Machine", "fpu_type", "none")
+        parsed["fpu_softfloat"] = _get_bool(cfg, "Machine", "fpu_softfloat", False)
+        
+    # --- Video settings ---
+    if cfg.has_section("Video"):
+        parsed["gfxcard"] = _get_str(cfg, "Video", "gfxcard", "none")
+        
+    if cfg.has_section("3Dfx Voodoo Graphics"):
+        voodoo_type = _get_str(cfg, "3Dfx Voodoo Graphics", "type", "none")
+        parsed["voodoo_enabled"] = voodoo_type != "none"
+        if parsed["voodoo_enabled"]:
+            parsed["voodoo_type"] = voodoo_type
+            
+    # --- Sound settings ---
+    if cfg.has_section("Sound"):
+        parsed["sndcard"] = _get_str(cfg, "Sound", "sndcard", "none")
+        parsed["midi_device"] = _get_str(cfg, "Sound", "midi_device", "none")
+        parsed["fm_driver"] = _get_str(cfg, "Sound", "fm_driver", "nuked")
+
+    # --- Network settings ---
+    if cfg.has_section("Network"):
+        parsed["net_card"] = _get_str(cfg, "Network", "net_01_card", "none")
+        parsed["net_type"] = _get_str(cfg, "Network", "net_01_net_type", "slirp")
+        parsed["net_host_dev"] = _get_str(cfg, "Network", "net_01_host_device", "")
+        
+    # --- Storage Controllers ---
+    if cfg.has_section("Storage controllers"):
+        # NEW: Check for modern hdc_1 first, then fallback to old hdc
+        hdc_val = _get_str(cfg, "Storage controllers", "hdc_1", "none")
+        if hdc_val == "none":
+            hdc_val = _get_str(cfg, "Storage controllers", "hdc", "none")
+        parsed["hdd_controller"] = hdc_val
+        
+        parsed["scsi_card"] = _get_str(cfg, "Storage controllers", "scsi_card", "none")
+        parsed["fdc_card"] = _get_str(cfg, "Storage controllers", "fdc", "none")
+        
+    # --- Hard Disks ---
+    if cfg.has_section("Hard disks"):
+        for i in range(1, 9):
+            n = f"{i:02d}"
+            params = _get_str(cfg, "Hard disks", f"hdd_{n}_parameters", "")
+            if params:
+                parsed[f"hdd_{n}_enabled"] = True
+                parts = [p.strip() for p in params.split(",")]
+                
+                if len(parts) >= 4:
+                    parsed[f"hdd_{n}_spt"] = int(parts[0]) if parts[0].isdigit() else 63
+                    parsed[f"hdd_{n}_heads"] = int(parts[1]) if parts[1].isdigit() else 16
+                    parsed[f"hdd_{n}_cylinders"] = int(parts[2]) if parts[2].isdigit() else 0
+                    parsed[f"hdd_{n}_size_mb"] = int(parts[3]) if parts[3].isdigit() else 0
+                if len(parts) >= 5:
+                    parsed[f"hdd_{n}_bus"] = parts[4]
+                    
+                # NEW: Save the original filename temporarily so we can move the file later
+                parsed[f"_hdd_{n}_fn_orig"] = _get_str(cfg, "Hard disks", f"hdd_{n}_fn", "")
+                parsed[f"hdd_{n}_speed"] = _get_str(cfg, "Hard disks", f"hdd_{n}_speed", "")
+                parsed[f"hdd_{n}_ide_channel"] = _get_str(cfg, "Hard disks", f"hdd_{n}_ide_channel", "")
+                
+    # --- Floppy and CD-ROM drives ---
+    if cfg.has_section("Floppy and CD-ROM drives"):
+        for i in range(1, 5):
+            n = f"{i:02d}"
+            f_type = _get_str(cfg, "Floppy and CD-ROM drives", f"fdd_{n}_type", "none")
+            parsed[f"fdd_{n}_type"] = f_type
+            if f_type != "none":
+                parsed[f"fdd_{n}_fn"] = _get_str(cfg, "Floppy and CD-ROM drives", f"fdd_{n}_fn", "")
+                parsed[f"fdd_{n}_turbo"] = _get_bool(cfg, "Floppy and CD-ROM drives", f"fdd_{n}_turbo", False)
+
+            cd_type = _get_str(cfg, "Floppy and CD-ROM drives", f"cdrom_{n}_type", "")
+            if cd_type and cd_type != "none":
+                parsed[f"cdrom_{n}_enabled"] = True
+                parsed[f"cdrom_{n}_drive_type"] = cd_type
+                parsed[f"cdrom_{n}_speed"] = _get_int(cfg, "Floppy and CD-ROM drives", f"cdrom_{n}_speed", 72)
+                parsed[f"cdrom_{n}_ide_channel"] = _get_str(cfg, "Floppy and CD-ROM drives", f"cdrom_{n}_ide_channel", "")
+                parsed[f"cdrom_{n}_fn"] = _get_str(cfg, "Floppy and CD-ROM drives", f"cdrom_{n}_image_path", "")
+
+    # --- Input / Ports ---
+    # 1. Try modern v4/v5 format first
+    if cfg.has_section("Input devices"):
+        parsed["mouse_type"] = _get_str(cfg, "Input devices", "mouse_type", "none")
+        parsed["joystick_type"] = _get_str(cfg, "Input devices", "joystick_type", "none")
+        parsed["keyboard_type"] = _get_str(cfg, "Input devices", "keyboard_type", "none")
+    else:
+        # 2. Fallback to older v3 formats
+        if cfg.has_section("Mouse"):
+            parsed["mouse_type"] = _get_str(cfg, "Mouse", "type", "none")
+        if cfg.has_section("Joystick"):
+            parsed["joystick_type"] = _get_str(cfg, "Joystick", "type", "none")
+        if cfg.has_section("Keyboard"):
+            parsed["keyboard_type"] = _get_str(cfg, "Keyboard", "type", "none")
+        
+    return parsed

--- a/backend/app/routers/vms.py
+++ b/backend/app/routers/vms.py
@@ -2,6 +2,8 @@ import logging
 import os
 import shutil
 from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File
+import uuid
+from .import_vms import VMImportRequest, scan_for_unregistered_folders, parse_86box_cfg
 
 log = logging.getLogger("86web")
 from sqlalchemy.orm import Session
@@ -192,6 +194,90 @@ async def create_vm(
 
     return _vm_to_response(vm)
 
+@router.get("/unregistered")
+async def get_unregistered_vms(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """Retrieves all folders in the vms directory that are not yet registered in the database."""
+    db_uuids = {vm.uuid for vm in db.query(VM).all()}
+    unregistered = scan_for_unregistered_folders(settings.vms_path, db_uuids)
+    return {"unregistered": unregistered}
+
+# ─── Import VMs ──────────────────────────────────────────────────────────────
+
+@router.post("/import")
+async def import_vm(
+    body: VMImportRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """Parses an existing 86box.cfg, writes it to the database, and assigns a UUID."""
+    source_path = os.path.join(settings.vms_path, body.folder_name)
+    cfg_path = os.path.join(source_path, "86box.cfg")
+    
+    if not os.path.isdir(source_path) or not os.path.exists(cfg_path):
+        raise HTTPException(404, "Folder or 86box.cfg not found")
+        
+    new_uuid = str(uuid.uuid4())
+    target_path = os.path.join(settings.vms_path, new_uuid)
+    
+    # Delegate the parsing logic
+    parsed_config = parse_86box_cfg(cfg_path)
+    
+    # --- NEW: Translate raw CPU Hz into the correct UI index ---
+    from ..hardware_lists import get_cpu_by_index
+    cpu_family = parsed_config.get("cpu_family", "8088")
+    raw_speed = parsed_config.pop("_raw_cpu_speed", 0)
+    speed_index = 0
+    if raw_speed > 0:
+        for i in range(50):  # Brute force check up to 50 speed steps
+            try:
+                rspeed, _ = get_cpu_by_index(cpu_family, i)
+                if rspeed == raw_speed:
+                    speed_index = i
+                    break
+            except Exception:
+                break  # Index out of bounds, stop searching
+    parsed_config["cpu_speed"] = speed_index
+    
+    # Rename the folder from whatever the user named it to the proper UUID
+    try:
+        os.rename(source_path, target_path)
+    except Exception as e:
+        raise HTTPException(500, f"Failed to rename folder: {e}")
+        
+    # --- NEW: Move hard disks into 86web's strict folder structure ---
+    os.makedirs(os.path.join(target_path, "hdd"), exist_ok=True)
+    for i in range(1, 9):
+        n = f"{i:02d}"
+        orig_fn = parsed_config.pop(f"_hdd_{n}_fn_orig", None)
+        if orig_fn and parsed_config.get(f"hdd_{n}_enabled"):
+            old_file = orig_fn if os.path.isabs(orig_fn) else os.path.join(target_path, orig_fn)
+            new_file = os.path.join(target_path, "hdd", f"hdd{i}.img")
+            if os.path.exists(old_file) and old_file != new_file:
+                try:
+                    shutil.move(old_file, new_file)
+                except Exception as e:
+                    log.warning(f"Failed to move HDD {old_file} to {new_file}: {e}")
+
+    # Write the new entry into the database
+    new_vm = VM(
+        name=body.vm_name,
+        description=body.description,
+        uuid=new_uuid,
+        config=parsed_config,
+        user_id=current_user.id,
+        group_id=body.group_id
+    )
+    db.add(new_vm)
+    db.commit()
+    db.refresh(new_vm)
+    
+    # Trigger a clean write to ensure the config format perfectly matches 86web's standard
+    _write_86box_config(new_vm, target_path)
+    
+    return {"status": "imported", "vm": {"id": new_vm.id, "uuid": new_vm.uuid}}
 
 @router.get("/{vm_id}", response_model=VMResponse)
 async def get_vm(
@@ -820,7 +906,6 @@ async def delete_media(
     if not os.path.exists(fp):
         raise HTTPException(404, "File not found")
     os.remove(fp)
-
 
 # ─── Drive Management (mount / eject / blank floppy) ─────────────────────────
 

--- a/frontend/src/components/ImportVMModal.tsx
+++ b/frontend/src/components/ImportVMModal.tsx
@@ -1,0 +1,215 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { X, FolderDown, AlertCircle } from 'lucide-react'
+import { vmApi } from '../lib/api'
+import { clsx } from 'clsx'
+
+interface Props {
+  // Pass the available groups so the user can assign the imported VM to one
+  groups: { id: number; name: string; color: string; network_enabled: boolean }[]
+  onSuccess: (vmId: number) => void
+  onClose: () => void
+}
+
+interface UnregisteredFolder {
+  folder_name: string
+  machine: string
+}
+
+export default function ImportVMModal({ groups, onSuccess, onClose }: Props) {
+  const [loading, setLoading] = useState(true)
+  const [folders, setFolders] = useState<UnregisteredFolder[]>([])
+  const [error, setError] = useState('')
+  const [importing, setImporting] = useState(false)
+
+  // Form State
+  const [selectedFolder, setSelectedFolder] = useState<string>('')
+  const [vmName, setVmName] = useState('')
+  const [description, setDescription] = useState('')
+  const [groupId, setGroupId] = useState<number | null>(null)
+
+  // Fetch the unregistered folders when the modal opens
+  useEffect(() => {
+    async function fetchFolders() {
+      try {
+        const res = await vmApi.getUnregistered()
+        setFolders(res.unregistered)
+        if (res.unregistered.length > 0) {
+          // Pre-select the first folder in the list
+          setSelectedFolder(res.unregistered[0].folder_name)
+          // Auto-fill the VM name with the folder name
+          setVmName(res.unregistered[0].folder_name)
+        }
+      } catch (err: any) {
+        setError(err.message || 'Failed to scan for VM folders.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchFolders()
+  }, [])
+
+  // Auto-update the VM name if the user changes the folder selection (and hasn't typed a custom name yet)
+  function handleFolderSelect(folder: string) {
+    if (vmName === selectedFolder) {
+      setVmName(folder)
+    }
+    setSelectedFolder(folder)
+  }
+
+  async function handleImport() {
+    if (!selectedFolder) {
+      setError('Please select a folder to import.')
+      return
+    }
+    if (!vmName.trim()) {
+      setError('VM name is required.')
+      return
+    }
+
+    setImporting(true)
+    setError('')
+
+    try {
+      const result = await vmApi.importVM({
+        folder_name: selectedFolder,
+        vm_name: vmName,
+        description: description,
+        group_id: groupId,
+      })
+      onSuccess(result.vm.id)
+      onClose()
+    } catch (err: any) {
+      setError(err.message || 'Import failed.')
+      setImporting(false)
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+      <div className="bg-slate-900 border border-slate-700 rounded-xl shadow-2xl w-full max-w-lg flex flex-col overflow-hidden">
+        
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-slate-800 bg-slate-900/50">
+          <div className="flex items-center gap-2">
+            <FolderDown className="w-5 h-5 text-blue-400" />
+            <h2 className="text-base font-semibold text-white">Import VM from Server</h2>
+          </div>
+          <button onClick={onClose} disabled={importing} className="btn-ghost p-1.5 rounded-lg text-slate-400 hover:text-white transition-colors">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6 space-y-5">
+          {loading ? (
+            <div className="flex flex-col items-center justify-center py-8 space-y-3">
+              <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+              <p className="text-sm text-slate-400">Scanning server directory for VMs...</p>
+            </div>
+          ) : folders.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 space-y-3 text-center">
+              <AlertCircle className="w-10 h-10 text-slate-500" />
+              <div>
+                <p className="text-sm font-medium text-slate-300">No unregistered VMs found</p>
+                <p className="text-xs text-slate-500 mt-1 max-w-[280px]">
+                  Drop a VM folder (containing an <code className="bg-slate-800 px-1 rounded text-amber-300">86box.cfg</code>) into the <code className="bg-slate-800 px-1 rounded text-emerald-300">vms/</code> directory on your server.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <>
+              {/* Folder Selection */}
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-slate-300">Select Folder to Import</label>
+                <select 
+                  className="input w-full" 
+                  value={selectedFolder} 
+                  onChange={e => handleFolderSelect(e.target.value)}
+                  disabled={importing}
+                >
+                  {folders.map(f => (
+                    <option key={f.folder_name} value={f.folder_name}>
+                      {f.folder_name} ({f.machine})
+                    </option>
+                  ))}
+                </select>
+                <p className="text-xs text-slate-500">
+                  This folder will be renamed to a unique UUID upon import.
+                </p>
+              </div>
+
+              <hr className="border-slate-800" />
+
+              {/* VM Details */}
+              <div className="space-y-4">
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium text-slate-300">VM Name</label>
+                  <input 
+                    type="text" 
+                    className="input w-full" 
+                    value={vmName} 
+                    onChange={e => setVmName(e.target.value)} 
+                    placeholder="e.g. Windows 95"
+                    disabled={importing}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium text-slate-300">Description (Optional)</label>
+                  <input 
+                    type="text" 
+                    className="input w-full" 
+                    value={description} 
+                    onChange={e => setDescription(e.target.value)} 
+                    placeholder="A brief description of this machine"
+                    disabled={importing}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium text-slate-300">Group (Optional)</label>
+                  <div className="flex items-center gap-2">
+                    {groupId && (() => { const g = groups.find(g => g.id === groupId); return g ? <span className="w-3 h-3 rounded-sm flex-shrink-0" style={{ backgroundColor: g.color }} /> : null })()}
+                    <select 
+                      className="input flex-1" 
+                      value={groupId ?? ''} 
+                      onChange={e => setGroupId(e.target.value ? parseInt(e.target.value) : null)}
+                      disabled={importing}
+                    >
+                      <option value="">No group</option>
+                      {groups.map(g => <option key={g.id} value={g.id}>{g.name}</option>)}
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-6 py-4 border-t border-slate-800 bg-slate-900/50">
+          {error ? (
+            <p className="text-sm text-red-400">{error}</p>
+          ) : (
+            <div /> // Empty div to keep the flex layout balanced
+          )}
+          <div className="flex items-center gap-2">
+            <button onClick={onClose} disabled={importing} className="btn-secondary text-sm">
+              Cancel
+            </button>
+            <button 
+              onClick={handleImport} 
+              disabled={importing || folders.length === 0 || !selectedFolder} 
+              className={clsx("btn-primary text-sm", importing && "opacity-75 cursor-not-allowed")}
+            >
+              {importing ? 'Importing...' : 'Import VM'}
+            </button>
+          </div>
+        </div>
+
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -62,6 +62,17 @@ export const vmApi = {
 
   get: (id: number) => request<VM>(`/vms/${id}`),
 
+  // NEW: Fetches the list of VM folders that exist in vms/ but are not yet registered in the database
+  getUnregistered: () => 
+    request<{ unregistered: { folder_name: string; machine: string }[] }>('/vms/unregistered'),
+
+  // NEW: Sends the command to import one of these discovered folders as a new VM
+  importVM: (data: { folder_name: string; vm_name: string; description?: string; group_id?: number | null }) =>
+    request<{ status: string; vm: { id: number; uuid: string } }>('/vms/import', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+
   create: (data: { name: string; description?: string; group_id?: number; config: VMConfig }) =>
     request<VM>('/vms', { method: 'POST', body: JSON.stringify(data) }),
 

--- a/frontend/src/pages/VMsPage.tsx
+++ b/frontend/src/pages/VMsPage.tsx
@@ -3,13 +3,14 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   Plus, Play, Square, RotateCcw, Pencil, Trash2, Monitor, Loader2,
   FolderPlus, ChevronDown, ChevronRight, LayoutGrid, List,
-  HardDrive, Eye, Network, Settings2, CloudOff,
+  HardDrive, Eye, Network, Settings2, CloudOff, FolderDown
 } from 'lucide-react'
 import { vmApi, systemApi, formatBytes } from '../lib/api'
 import { VM, VMConfig, VMGroup } from '../types'
 import { useStore } from '../store/useStore'
 import VMConfigModal from '../components/VMConfigModal'
 import ConfirmDialog from '../components/ConfirmDialog'
+import ImportVMModal from '../components/ImportVMModal'
 import { clsx } from 'clsx'
 
 type ViewMode = 'grid' | 'list'
@@ -404,6 +405,7 @@ export default function VMsPage() {
   const { addToast, authConfig, serverOnline, openTabs, updateTabGroupColor } = useStore()
   const [view, setView] = useState<ViewMode>('grid')
   const [showCreateVM, setShowCreateVM] = useState(false)
+  const [showImportVM, setShowImportVM] = useState(false)
   const [editVM, setEditVM] = useState<VM | null>(null)
   const [showCreateGroup, setShowCreateGroup] = useState(false)
   const [editGroup, setEditGroup] = useState<VMGroup | null>(null)
@@ -550,6 +552,17 @@ export default function VMsPage() {
           </button>
           <button
             disabled={!serverOnline}
+            onClick={() => atVMQuota ? addToast(`VM quota reached (${userStats!.max_vms} VMs). Delete a VM to import a new one.`, 'error') : setShowImportVM(true)}
+            className={clsx(
+              'flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg text-white bg-amber-500 hover:bg-amber-600 shadow-sm transition-colors', 
+              (atVMQuota || !serverOnline) && 'opacity-60 cursor-not-allowed'
+            )}
+            title={!serverOnline ? 'Server unavailable' : atVMQuota ? `Quota reached: ${userStats?.max_vms} VMs` : undefined}
+          >
+            <FolderDown className="w-4 h-4" />Import VM
+          </button>
+          <button
+            disabled={!serverOnline}
             onClick={() => atVMQuota ? addToast(`VM quota reached (${userStats!.max_vms} VMs). Delete a VM to create a new one.`, 'error') : setShowCreateVM(true)}
             className={clsx('btn-primary', (atVMQuota || !serverOnline) && 'opacity-60')}
             title={!serverOnline ? 'Server unavailable' : atVMQuota ? `Quota reached: ${userStats?.max_vms} VMs` : undefined}
@@ -644,6 +657,19 @@ export default function VMsPage() {
           onClose={() => setShowCreateVM(false)}
           onSave={async (name, desc, groupId, config) => {
             await createVMMut.mutateAsync({ name, description: desc, group_id: groupId ?? undefined, config })
+          }}
+        />
+      )}
+
+      {/* Import VM modal */}
+      {showImportVM && (
+        <ImportVMModal
+          groups={groups}
+          onClose={() => setShowImportVM(false)}
+          onSuccess={(vmId) => {
+             // Invalidate the cache to reload the VM list automatically
+             qc.invalidateQueries({ queryKey: ['vms'] })
+             addToast('VM successfully imported!', 'success')
           }}
         />
       )}


### PR DESCRIPTION
**Description:**
This PR introduces the ability to seamlessly import existing, unregistered 86Box VM folders directly from the server's vms directory into the 86web database.

Previously, users migrating to 86web had to manually recreate their VMs and re-attach their disk images. With this PR, the system scans for orphaned VM folders, parses their existing 86box.cfg, auto-migrates the storage layout, and registers them with a new UUID.
I intentionally ignored uploading zipped files, as this might lead to huge files being uploaded. Manually copy the VMs folder into 86Web's VM Folder and give it a go.

**Key Features & Changes:**

Backend (backend/app/routers/):
- New Endpoints: Added GET /api/vms/unregistered to scan for orphaned folders and POST /api/vms/import to execute the import and database registration.
- Smart Config Parser (`import_vms.py`): * Safely reads existing 86box.cfg files, explicitly ignoring Windows BOM characters (utf-8-sig) to prevent configparser crashes.
- Translates raw CPU speed (Hz) back into the correct UI dropdown index via a brute-force lookup.
- Backwards Compatibility: The parser supports both modern 86Box v4 / v5 formats (e.g., [Input devices], hdc_1) and older v3 legacy formats (e.g., [Mouse], hdc), ensuring older VMs are imported correctly. <- This was a tough one for me.
- Auto-Migration of Disks: Automatically detects existing hard disk images and moves them into 86web's strict hdd subdirectory structure (`hdd1.img`, etc.) before rewriting the config.

Frontend (frontend/src/):
- API Client (`api.ts`): Added `getUnregistered` and `importVM` methods.
- New UI Component (`ImportVMModal.tsx`): A native-feeling modal that lists available unregistered folders and allows the user to define a name, description, and group for the imported VM.
- Dashboard Integration (`VMsPage.tsx`): Added an eye-catching amber "Import VM" button right next to the "New VM" button, fully integrated with the existing Tailwind design system and quota checks.

**Testing Notes:**
Successfully tested with legacy v3 .cfg files and modern v4 / v5 files.
Tested edge cases where original hard disk images were located in the root folder (successfully migrated to /hdd/).
Verified that the FastAPI routing order handles the new endpoints correctly without triggering the /{vm_id} catch-all route.
There is a chance that I did not catch all legacy configurations, but in that case they will only need to be selected again in the VM config window. I would say the most important 99% can be properly imported :-).

**Screenshots:**

<img width="463" height="54" alt="Buttons" src="https://github.com/user-attachments/assets/3b0b0568-32b3-4cd5-90cd-720d9f5ee144" />
<img width="523" height="530" alt="Import Screen" src="https://github.com/user-attachments/assets/1ee7b9ae-d3ad-4f3e-855c-ce87c08ccf19" />
<img width="525" height="364" alt="Nothing to import" src="https://github.com/user-attachments/assets/36768313-dd57-4eab-89b4-ba32333a46b4" />
<img width="524" height="526" alt="Import multiple VMs selection" src="https://github.com/user-attachments/assets/ee77174a-d5cd-4f85-b43d-e670ed66bc88" />

(Closes #4)