### PR TITLE
feat: access and share management

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -3,10 +3,54 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from .config import get_settings
 import os
+import sqlite3
 
 settings = get_settings()
 
 os.makedirs(os.path.dirname(settings.db_path), exist_ok=True)
+
+# --- NEU: Auto-Migration ---
+def apply_migrations(db_path: str):
+    """Checking existing DB and adding missing columns / tables."""
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        # 1. Check if users table exists
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='users'")
+        if cursor.fetchone():
+            # Read users column tables
+            cursor.execute("PRAGMA table_info(users)")
+            columns = [info[1] for info in cursor.fetchall()]
+            
+            # Add missing permission columns (1 = True in SQLite)
+            if "can_manage_vms" not in columns:
+                cursor.execute("ALTER TABLE users ADD COLUMN can_manage_vms BOOLEAN NOT NULL DEFAULT 1")
+                cursor.execute("ALTER TABLE users ADD COLUMN can_manage_groups BOOLEAN NOT NULL DEFAULT 1")
+                cursor.execute("ALTER TABLE users ADD COLUMN can_access_library BOOLEAN NOT NULL DEFAULT 1")
+                cursor.execute("ALTER TABLE users ADD COLUMN can_upload_images BOOLEAN NOT NULL DEFAULT 1")
+                print("Migration: Added new Permission Columns to 'users'.")
+
+        # 2. Check if vms table exists
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='vms'")
+        if cursor.fetchone():
+            cursor.execute("PRAGMA table_info(vms)")
+            columns = [info[1] for info in cursor.fetchall()]
+            
+            # Add missing locked_by column
+            if "locked_by_user_id" not in columns:
+                cursor.execute("ALTER TABLE vms ADD COLUMN locked_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL")
+                print("Migration: Column 'locked_by_user_id' was added to 'vms'.")
+                
+        conn.commit()
+    except Exception as e:
+        print(f"Error during Database-Migration: {e}")
+    finally:
+        conn.close()
+
+# Migration Part
+apply_migrations(settings.db_path)
+# ------------------------------------
 
 engine = create_engine(
     f"sqlite:///{settings.db_path}",
@@ -15,7 +59,6 @@ engine = create_engine(
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
-
 
 def get_db():
     db = SessionLocal()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -103,7 +103,7 @@ async def _refresh_hardware_db():
     else:
         log.info("Hardware database not in config — will download and generate now.")
 
-    result = await refresh_hardware_json(config_dir, cache_dir)
+    result = await refresh_hardware_json(config_dir, cache_dir=cache_dir)
     if result:
         log.info("Hardware database ready: %s", result)
     else:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,12 +1,25 @@
 import uuid as _uuid
 from sqlalchemy import (
     Column, Integer, String, Boolean, DateTime, ForeignKey,
-    Text, JSON, Float
+    Text, JSON, Float, Table
 )
 from sqlalchemy.orm import relationship
 from datetime import datetime
 from .database import Base
 
+user_vm_access = Table(
+    "user_vm_access",
+    Base.metadata,
+    Column("user_id", Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
+    Column("vm_id", Integer, ForeignKey("vms.id", ondelete="CASCADE"), primary_key=True)
+)
+
+user_group_access = Table(
+    "user_group_access",
+    Base.metadata,
+    Column("user_id", Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
+    Column("group_id", Integer, ForeignKey("vm_groups.id", ondelete="CASCADE"), primary_key=True),
+)
 
 class User(Base):
     __tablename__ = "users"
@@ -14,17 +27,27 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String(64), unique=True, index=True, nullable=False)
     email = Column(String(256), unique=True, index=True, nullable=False)
-    hashed_password = Column(String(256), nullable=True)  # Null for LDAP users
+    hashed_password = Column(String(256), nullable=True)
     is_admin = Column(Boolean, default=False, nullable=False)
     is_active = Column(Boolean, default=True, nullable=False)
     is_ldap = Column(Boolean, default=False, nullable=False)
     max_vms = Column(Integer, default=10, nullable=False)
     max_storage_gb = Column(Integer, default=100, nullable=False)
+    
+    can_manage_vms = Column(Boolean, default=True, nullable=False)
+    can_manage_groups = Column(Boolean, default=True, nullable=False)
+    can_access_library = Column(Boolean, default=True, nullable=False)
+    can_upload_images = Column(Boolean, default=True, nullable=False)
+
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     last_login = Column(DateTime, nullable=True)
 
-    vms = relationship("VM", back_populates="owner", cascade="all, delete-orphan")
+    # Existing Relations (User)
+    vms = relationship("VM", foreign_keys="[VM.user_id]", back_populates="owner", cascade="all, delete-orphan")
     groups = relationship("VMGroup", back_populates="owner", cascade="all, delete-orphan")
+    
+    accessible_vms = relationship("VM", secondary=user_vm_access, back_populates="shared_with")
+    accessible_groups = relationship("VMGroup", secondary=user_group_access, back_populates="shared_with")
 
 
 class VMGroup(Base):
@@ -40,6 +63,9 @@ class VMGroup(Base):
 
     owner = relationship("User", back_populates="groups")
     vms = relationship("VM", back_populates="group")
+    
+    # NEW: With which group is this VM shared?
+    shared_with = relationship("User", secondary=user_group_access, back_populates="accessible_groups")
 
 
 class VM(Base):
@@ -52,25 +78,25 @@ class VM(Base):
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     group_id = Column(Integer, ForeignKey("vm_groups.id"), nullable=True)
 
-    # Status: stopped | starting | running | paused | error
     status = Column(String(32), default="stopped", nullable=False)
 
-    # Network (assigned by runner when VM starts)
+    # NEW: Concurrency Lock
+    locked_by_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+
     vnc_port = Column(Integer, nullable=True)
     ws_port = Column(Integer, nullable=True)
-
-    # Full 86Box configuration stored as JSON
     config = Column(JSON, nullable=False, default=dict)
-
-    # Disk usage in bytes (updated periodically)
     disk_usage_bytes = Column(Integer, default=0, nullable=False)
-
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     last_started = Column(DateTime, nullable=True)
     last_stopped = Column(DateTime, nullable=True)
 
-    owner = relationship("User", back_populates="vms")
+    owner = relationship("User", back_populates="vms", foreign_keys=[user_id])
     group = relationship("VMGroup", back_populates="vms")
+    
+    # NEW: Relations for lock and access
+    locked_by = relationship("User", foreign_keys=[locked_by_user_id])
+    shared_with = relationship("User", secondary=user_vm_access, back_populates="accessible_vms")
 
 
 class SystemSetting(Base):

--- a/backend/app/routers/import_vms.py
+++ b/backend/app/routers/import_vms.py
@@ -1,0 +1,165 @@
+import os
+import configparser
+from pydantic import BaseModel
+
+class VMImportRequest(BaseModel):
+    folder_name: str
+    vm_name: str
+    description: str = ""
+    group_id: int | None = None
+
+def scan_for_unregistered_folders(vms_path: str, db_uuids: set) -> list:
+    """Scans the vms_path for directories containing an 86box.cfg that are not registered in the DB."""
+    unregistered = []
+    if os.path.exists(vms_path):
+        for folder_name in os.listdir(vms_path):
+            folder_path = os.path.join(vms_path, folder_name)
+            
+            # Check if it's a directory and not already registered by its folder name (which should be the UUID)
+            if os.path.isdir(folder_path) and folder_name not in db_uuids:
+                cfg_path = os.path.join(folder_path, "86box.cfg")
+                if os.path.exists(cfg_path):
+                    machine_name = "Unknown Machine"
+                    try:
+                        cfg = configparser.RawConfigParser()
+                        cfg.read(cfg_path, encoding="utf-8-sig")
+                        if cfg.has_option("Machine", "machine"):
+                            machine_name = cfg.get("Machine", "machine")
+                    except Exception:
+                        pass
+                        
+                    unregistered.append({
+                        "folder_name": folder_name,
+                        "machine": machine_name
+                    })
+    return unregistered
+
+# --- Helper functions for safe type parsing ---
+
+def _get_int(cfg: configparser.RawConfigParser, section: str, key: str, default: int = 0) -> int:
+    try:
+        return int(cfg.get(section, key))
+    except Exception:
+        return default
+
+def _get_bool(cfg: configparser.RawConfigParser, section: str, key: str, default: bool = False) -> bool:
+    try:
+        val = cfg.get(section, key).strip().lower()
+        return val in ("1", "true", "yes", "on")
+    except Exception:
+        return default
+
+def _get_str(cfg: configparser.RawConfigParser, section: str, key: str, default: str = "") -> str:
+    try:
+        return cfg.get(section, key)
+    except Exception:
+        return default
+
+def parse_86box_cfg(cfg_path: str) -> dict:
+    """Reads an existing 86box.cfg and translates it into the JSON state format used by the React frontend."""
+    cfg = configparser.RawConfigParser()
+    cfg.read(cfg_path, encoding="utf-8-sig")
+    
+    parsed = {}
+    
+    # --- Machine settings ---
+    if cfg.has_section("Machine"):
+        parsed["machine"] = _get_str(cfg, "Machine", "machine", "ibm_pc")
+        parsed["mem_size"] = _get_int(cfg, "Machine", "mem_size", 64)
+        parsed["cpu_family"] = _get_str(cfg, "Machine", "cpu_family", "")
+        # NEW: Keep the raw Hz value temporarily to translate it into an index later
+        parsed["_raw_cpu_speed"] = _get_int(cfg, "Machine", "cpu_speed", 0)
+        parsed["cpu_use_dynarec"] = _get_bool(cfg, "Machine", "cpu_use_dynarec", True)
+        parsed["time_sync"] = _get_str(cfg, "Machine", "time_sync", "local")
+        parsed["fpu_type"] = _get_str(cfg, "Machine", "fpu_type", "none")
+        parsed["fpu_softfloat"] = _get_bool(cfg, "Machine", "fpu_softfloat", False)
+        
+    # --- Video settings ---
+    if cfg.has_section("Video"):
+        parsed["gfxcard"] = _get_str(cfg, "Video", "gfxcard", "none")
+        
+    if cfg.has_section("3Dfx Voodoo Graphics"):
+        voodoo_type = _get_str(cfg, "3Dfx Voodoo Graphics", "type", "none")
+        parsed["voodoo_enabled"] = voodoo_type != "none"
+        if parsed["voodoo_enabled"]:
+            parsed["voodoo_type"] = voodoo_type
+            
+    # --- Sound settings ---
+    if cfg.has_section("Sound"):
+        parsed["sndcard"] = _get_str(cfg, "Sound", "sndcard", "none")
+        parsed["midi_device"] = _get_str(cfg, "Sound", "midi_device", "none")
+        parsed["fm_driver"] = _get_str(cfg, "Sound", "fm_driver", "nuked")
+
+    # --- Network settings ---
+    if cfg.has_section("Network"):
+        parsed["net_card"] = _get_str(cfg, "Network", "net_01_card", "none")
+        parsed["net_type"] = _get_str(cfg, "Network", "net_01_net_type", "slirp")
+        parsed["net_host_dev"] = _get_str(cfg, "Network", "net_01_host_device", "")
+        
+    # --- Storage Controllers ---
+    if cfg.has_section("Storage controllers"):
+        # NEW: Check for modern hdc_1 first, then fallback to old hdc
+        hdc_val = _get_str(cfg, "Storage controllers", "hdc_1", "none")
+        if hdc_val == "none":
+            hdc_val = _get_str(cfg, "Storage controllers", "hdc", "none")
+        parsed["hdd_controller"] = hdc_val
+        
+        parsed["scsi_card"] = _get_str(cfg, "Storage controllers", "scsi_card", "none")
+        parsed["fdc_card"] = _get_str(cfg, "Storage controllers", "fdc", "none")
+        
+    # --- Hard Disks ---
+    if cfg.has_section("Hard disks"):
+        for i in range(1, 9):
+            n = f"{i:02d}"
+            params = _get_str(cfg, "Hard disks", f"hdd_{n}_parameters", "")
+            if params:
+                parsed[f"hdd_{n}_enabled"] = True
+                parts = [p.strip() for p in params.split(",")]
+                
+                if len(parts) >= 4:
+                    parsed[f"hdd_{n}_spt"] = int(parts[0]) if parts[0].isdigit() else 63
+                    parsed[f"hdd_{n}_heads"] = int(parts[1]) if parts[1].isdigit() else 16
+                    parsed[f"hdd_{n}_cylinders"] = int(parts[2]) if parts[2].isdigit() else 0
+                    parsed[f"hdd_{n}_size_mb"] = int(parts[3]) if parts[3].isdigit() else 0
+                if len(parts) >= 5:
+                    parsed[f"hdd_{n}_bus"] = parts[4]
+                    
+                # NEW: Save the original filename temporarily so we can move the file later
+                parsed[f"_hdd_{n}_fn_orig"] = _get_str(cfg, "Hard disks", f"hdd_{n}_fn", "")
+                parsed[f"hdd_{n}_speed"] = _get_str(cfg, "Hard disks", f"hdd_{n}_speed", "")
+                parsed[f"hdd_{n}_ide_channel"] = _get_str(cfg, "Hard disks", f"hdd_{n}_ide_channel", "")
+                
+    # --- Floppy and CD-ROM drives ---
+    if cfg.has_section("Floppy and CD-ROM drives"):
+        for i in range(1, 5):
+            n = f"{i:02d}"
+            f_type = _get_str(cfg, "Floppy and CD-ROM drives", f"fdd_{n}_type", "none")
+            parsed[f"fdd_{n}_type"] = f_type
+            if f_type != "none":
+                parsed[f"fdd_{n}_fn"] = _get_str(cfg, "Floppy and CD-ROM drives", f"fdd_{n}_fn", "")
+                parsed[f"fdd_{n}_turbo"] = _get_bool(cfg, "Floppy and CD-ROM drives", f"fdd_{n}_turbo", False)
+
+            cd_type = _get_str(cfg, "Floppy and CD-ROM drives", f"cdrom_{n}_type", "")
+            if cd_type and cd_type != "none":
+                parsed[f"cdrom_{n}_enabled"] = True
+                parsed[f"cdrom_{n}_drive_type"] = cd_type
+                parsed[f"cdrom_{n}_speed"] = _get_int(cfg, "Floppy and CD-ROM drives", f"cdrom_{n}_speed", 72)
+                parsed[f"cdrom_{n}_ide_channel"] = _get_str(cfg, "Floppy and CD-ROM drives", f"cdrom_{n}_ide_channel", "")
+                parsed[f"cdrom_{n}_fn"] = _get_str(cfg, "Floppy and CD-ROM drives", f"cdrom_{n}_image_path", "")
+
+    # --- Input / Ports ---
+    # 1. Try modern v4/v5 format first
+    if cfg.has_section("Input devices"):
+        parsed["mouse_type"] = _get_str(cfg, "Input devices", "mouse_type", "none")
+        parsed["joystick_type"] = _get_str(cfg, "Input devices", "joystick_type", "none")
+        parsed["keyboard_type"] = _get_str(cfg, "Input devices", "keyboard_type", "none")
+    else:
+        # 2. Fallback to older v3 formats
+        if cfg.has_section("Mouse"):
+            parsed["mouse_type"] = _get_str(cfg, "Mouse", "type", "none")
+        if cfg.has_section("Joystick"):
+            parsed["joystick_type"] = _get_str(cfg, "Joystick", "type", "none")
+        if cfg.has_section("Keyboard"):
+            parsed["keyboard_type"] = _get_str(cfg, "Keyboard", "type", "none")
+        
+    return parsed

--- a/backend/app/routers/library.py
+++ b/backend/app/routers/library.py
@@ -92,7 +92,10 @@ def _safe_path(base: str, rel: str) -> str:
 
 @router.get("/")
 async def get_library(current_user: User = Depends(get_current_user)):
+    if not current_user.is_admin and not current_user.can_access_library:
+        raise HTTPException(403, "No access to library")
     lib = settings.library_path
+    
     if not os.path.isdir(lib):
         return []
     return _build_tree(lib)
@@ -119,6 +122,9 @@ async def create_images_directory(
     body: MkdirBody,
     current_user: User = Depends(get_current_user),
 ):
+    if not current_user.is_admin and not current_user.can_upload_images:
+        raise HTTPException(403, "No permission to upload or manage images")
+    
     images_dir = _user_images_dir(current_user)
     os.makedirs(images_dir, exist_ok=True)
     full = _safe_path(images_dir, body.path)
@@ -136,6 +142,9 @@ async def upload_image(
     path: str = Form(""),
     current_user: User = Depends(get_current_user),
 ):
+    if not current_user.is_admin and not current_user.can_upload_images:
+        raise HTTPException(403, "No permission to upload or manage images")
+    
     images_dir = _user_images_dir(current_user)
     target_dir = _safe_path(images_dir, path) if path.strip("/") else images_dir
     os.makedirs(target_dir, exist_ok=True)
@@ -161,6 +170,9 @@ async def delete_image(
     rel_path: str,
     current_user: User = Depends(get_current_user),
 ):
+    if not current_user.is_admin and not current_user.can_upload_images:
+        raise HTTPException(403, "No permission to upload or manage images")
+    
     images_dir = _user_images_dir(current_user)
     full = _safe_path(images_dir, rel_path)
 
@@ -187,6 +199,9 @@ async def move_image(
     body: MoveBody,
     current_user: User = Depends(get_current_user),
 ):
+    if not current_user.is_admin and not current_user.can_upload_images:
+        raise HTTPException(403, "No permission to upload or manage images")
+    
     images_dir = _user_images_dir(current_user)
     src_full = _safe_path(images_dir, body.src)
     dst_full = _safe_path(images_dir, body.dst)

--- a/backend/app/routers/media.py
+++ b/backend/app/routers/media.py
@@ -36,6 +36,9 @@ async def upload_shared_media(
     file: UploadFile = File(...),
     current_user: User = Depends(get_current_user),
 ):
+    if not current_user.is_admin and not current_user.can_upload_images:
+        raise HTTPException(403, "No permission to upload or manage images")
+    
     """Upload a file to the user's shared media pool."""
     mdir = _shared_media_dir(current_user.id)
     os.makedirs(mdir, exist_ok=True)
@@ -54,6 +57,9 @@ async def delete_shared_media(
     filename: str,
     current_user: User = Depends(get_current_user),
 ):
+    if not current_user.is_admin and not current_user.can_upload_images:
+        raise HTTPException(403, "No permission to upload or manage images")
+    
     """Delete a file from the user's shared media pool."""
     mdir = _shared_media_dir(current_user.id)
     safe_name = os.path.basename(filename)

--- a/backend/app/routers/system.py
+++ b/backend/app/routers/system.py
@@ -243,7 +243,8 @@ async def refresh_hardware_lists(current_user: User = Depends(require_admin)):
     from ..services.machine_db import refresh_hardware_json
 
     config_dir = Path(settings.data_path) / "config"
-    result = await refresh_hardware_json(config_dir, force=True)
+    cache_dir = Path(settings.data_path) / "cache"
+    result = await refresh_hardware_json(config_dir, cache_dir=cache_dir, force=True)
     if not result:
         raise HTTPException(500, "Hardware database refresh failed — check server logs.")
     # Reload the hardware lists module so the new data is used immediately

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -59,6 +59,10 @@ async def create_user(
         is_active=body.is_active,
         max_vms=body.max_vms,
         max_storage_gb=body.max_storage_gb,
+        can_manage_vms=body.can_manage_vms,
+        can_manage_groups=body.can_manage_groups,
+        can_access_library=body.can_access_library,
+        can_upload_images=body.can_upload_images,
     )
     db.add(user)
     db.commit()
@@ -115,6 +119,14 @@ async def update_user(
         user.max_storage_gb = body.max_storage_gb
     if body.password:
         user.hashed_password = hash_password(body.password)
+    if body.can_manage_vms is not None:
+        user.can_manage_vms = body.can_manage_vms
+    if body.can_manage_groups is not None:
+        user.can_manage_groups = body.can_manage_groups
+    if body.can_access_library is not None:
+        user.can_access_library = body.can_access_library
+    if body.can_upload_images is not None:
+        user.can_upload_images = body.can_upload_images
 
     db.commit()
     db.refresh(user)

--- a/backend/app/routers/vms.py
+++ b/backend/app/routers/vms.py
@@ -2,6 +2,8 @@ import logging
 import os
 import shutil
 from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File
+import uuid
+from .import_vms import VMImportRequest, scan_for_unregistered_folders, parse_86box_cfg
 
 log = logging.getLogger("86web")
 from sqlalchemy.orm import Session
@@ -192,6 +194,90 @@ async def create_vm(
 
     return _vm_to_response(vm)
 
+@router.get("/unregistered")
+async def get_unregistered_vms(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """Retrieves all folders in the vms directory that are not yet registered in the database."""
+    db_uuids = {vm.uuid for vm in db.query(VM).all()}
+    unregistered = scan_for_unregistered_folders(settings.vms_path, db_uuids)
+    return {"unregistered": unregistered}
+
+# ─── Import VMs ──────────────────────────────────────────────────────────────
+
+@router.post("/import")
+async def import_vm(
+    body: VMImportRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """Parses an existing 86box.cfg, writes it to the database, and assigns a UUID."""
+    source_path = os.path.join(settings.vms_path, body.folder_name)
+    cfg_path = os.path.join(source_path, "86box.cfg")
+    
+    if not os.path.isdir(source_path) or not os.path.exists(cfg_path):
+        raise HTTPException(404, "Folder or 86box.cfg not found")
+        
+    new_uuid = str(uuid.uuid4())
+    target_path = os.path.join(settings.vms_path, new_uuid)
+    
+    # Delegate the parsing logic
+    parsed_config = parse_86box_cfg(cfg_path)
+    
+    # --- NEW: Translate raw CPU Hz into the correct UI index ---
+    from ..hardware_lists import get_cpu_by_index
+    cpu_family = parsed_config.get("cpu_family", "8088")
+    raw_speed = parsed_config.pop("_raw_cpu_speed", 0)
+    speed_index = 0
+    if raw_speed > 0:
+        for i in range(50):  # Brute force check up to 50 speed steps
+            try:
+                rspeed, _ = get_cpu_by_index(cpu_family, i)
+                if rspeed == raw_speed:
+                    speed_index = i
+                    break
+            except Exception:
+                break  # Index out of bounds, stop searching
+    parsed_config["cpu_speed"] = speed_index
+    
+    # Rename the folder from whatever the user named it to the proper UUID
+    try:
+        os.rename(source_path, target_path)
+    except Exception as e:
+        raise HTTPException(500, f"Failed to rename folder: {e}")
+        
+    # --- NEW: Move hard disks into 86web's strict folder structure ---
+    os.makedirs(os.path.join(target_path, "hdd"), exist_ok=True)
+    for i in range(1, 9):
+        n = f"{i:02d}"
+        orig_fn = parsed_config.pop(f"_hdd_{n}_fn_orig", None)
+        if orig_fn and parsed_config.get(f"hdd_{n}_enabled"):
+            old_file = orig_fn if os.path.isabs(orig_fn) else os.path.join(target_path, orig_fn)
+            new_file = os.path.join(target_path, "hdd", f"hdd{i}.img")
+            if os.path.exists(old_file) and old_file != new_file:
+                try:
+                    shutil.move(old_file, new_file)
+                except Exception as e:
+                    log.warning(f"Failed to move HDD {old_file} to {new_file}: {e}")
+
+    # Write the new entry into the database
+    new_vm = VM(
+        name=body.vm_name,
+        description=body.description,
+        uuid=new_uuid,
+        config=parsed_config,
+        user_id=current_user.id,
+        group_id=body.group_id
+    )
+    db.add(new_vm)
+    db.commit()
+    db.refresh(new_vm)
+    
+    # Trigger a clean write to ensure the config format perfectly matches 86web's standard
+    _write_86box_config(new_vm, target_path)
+    
+    return {"status": "imported", "vm": {"id": new_vm.id, "uuid": new_vm.uuid}}
 
 @router.get("/{vm_id}", response_model=VMResponse)
 async def get_vm(
@@ -820,7 +906,6 @@ async def delete_media(
     if not os.path.exists(fp):
         raise HTTPException(404, "File not found")
     os.remove(fp)
-
 
 # ─── Drive Management (mount / eject / blank floppy) ─────────────────────────
 

--- a/backend/app/routers/vms.py
+++ b/backend/app/routers/vms.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File
 
 log = logging.getLogger("86web")
 from sqlalchemy.orm import Session
+from sqlalchemy import or_
 from typing import List, Optional
 from datetime import datetime
 
@@ -35,6 +36,9 @@ def _vm_to_response(vm: VM) -> VMResponse:
     if vm.group:
         resp.group_name = vm.group.name
         resp.group_color = vm.group.color
+    if vm.locked_by:
+        resp.locked_by_username = vm.locked_by.username
+    resp.shared_with_user_ids = [u.id for u in vm.shared_with]
     return resp
 
 
@@ -42,8 +46,20 @@ def _group_to_response(g: VMGroup) -> VMGroupResponse:
     resp = VMGroupResponse.model_validate(g)
     resp.vm_count = len(g.vms)
     resp.has_running_vms = any(vm.status == "running" for vm in g.vms)
+    resp.shared_with_user_ids = [u.id for u in g.shared_with]
     return resp
 
+def _get_accessible_vm(db: Session, vm_id: int, user: User) -> VM:
+    vm = db.query(VM).filter(VM.id == vm_id).first()
+    if not vm:
+        raise HTTPException(404, "VM not found")   
+    if vm.user_id == user.id:
+        return vm 
+    if user in vm.shared_with:
+        return vm
+    if vm.group and user in vm.group.shared_with:
+        return vm
+    raise HTTPException(403, "Access denied")
 
 # ─── VM Groups ────────────────────────────────────────────────────────────────
 
@@ -52,7 +68,13 @@ async def list_groups(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    groups = db.query(VMGroup).filter(VMGroup.user_id == current_user.id).all()
+    query = db.query(VMGroup).filter(
+        or_(
+            VMGroup.user_id == current_user.id,
+            VMGroup.shared_with.any(User.id == current_user.id)
+        )
+    )
+    groups = query.all()
     return [_group_to_response(g) for g in groups]
 
 
@@ -62,6 +84,9 @@ async def create_group(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    if not current_user.is_admin and not current_user.can_manage_groups:
+        raise HTTPException(403, "No Permission to create VM groups")
+
     group = VMGroup(
         name=body.name,
         description=body.description,
@@ -69,6 +94,11 @@ async def create_group(
         network_enabled=body.network_enabled,
         user_id=current_user.id,
     )
+
+    if hasattr(body, 'shared_with_user_ids') and body.shared_with_user_ids is not None:
+        shared_users = db.query(User).filter(User.id.in_(body.shared_with_user_ids)).all()
+        group.shared_with = shared_users
+
     db.add(group)
     db.commit()
     db.refresh(group)
@@ -82,9 +112,14 @@ async def update_group(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+
     group = db.query(VMGroup).filter(VMGroup.id == group_id, VMGroup.user_id == current_user.id).first()
     if not group:
         raise HTTPException(404, "Group not found")
+    
+    if not current_user.is_admin and not current_user.can_manage_groups:
+        raise HTTPException(403, "No Permission to edit / delete VM groups")
+
     if body.name is not None:
         group.name = body.name
     if body.description is not None:
@@ -96,6 +131,14 @@ async def update_group(
             if any(vm.status == "running" for vm in group.vms):
                 raise HTTPException(400, "Cannot change networking while a VM in the group is running. Stop all VMs first.")
         group.network_enabled = body.network_enabled
+
+    if hasattr(body, 'shared_with_user_ids') and body.shared_with_user_ids is not None:
+        if not current_user.is_admin and group.user_id != current_user.id:
+            raise HTTPException(403, "Only the owner can share this group")
+            
+        shared_users = db.query(User).filter(User.id.in_(body.shared_with_user_ids)).all()
+        group.shared_with = shared_users
+
     db.commit()
     db.refresh(group)
     return _group_to_response(group)
@@ -107,6 +150,9 @@ async def delete_group(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    if not current_user.is_admin and not current_user.can_manage_groups:
+        raise HTTPException(403, "No Permission to edit / delete VM groups")
+    
     group = db.query(VMGroup).filter(VMGroup.id == group_id, VMGroup.user_id == current_user.id).first()
     if not group:
         raise HTTPException(404, "Group not found")
@@ -119,25 +165,36 @@ async def delete_group(
 
 # ─── VMs ─────────────────────────────────────────────────────────────────────
 
-@router.get("/", response_model=List[VMResponse])
+@router.get("", response_model=List[VMResponse])
 async def list_vms(
     group_id: Optional[int] = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    query = db.query(VM).filter(VM.user_id == current_user.id)
+    query = db.query(VM).filter(
+        or_(
+            VM.user_id == current_user.id,
+            VM.shared_with.any(User.id == current_user.id),
+            VM.group.has(VMGroup.shared_with.any(User.id == current_user.id))
+        )
+    )
+
     if group_id is not None:
         query = query.filter(VM.group_id == group_id)
-    vms = query.order_by(VM.name).all()
+        
+    vms = query.all()
     return [_vm_to_response(vm) for vm in vms]
 
 
-@router.post("/", response_model=VMResponse, status_code=201)
+@router.post("", response_model=VMResponse, status_code=201)
 async def create_vm(
     body: VMCreate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    if not current_user.is_admin and not current_user.can_manage_vms:
+        raise HTTPException(403, "No Permission to create VMs")
+    
     # Quota checks (skipped when enforce_quotas is disabled)
     if _enforce_quotas(db):
         vm_count = db.query(VM).filter(VM.user_id == current_user.id).count()
@@ -163,6 +220,11 @@ async def create_vm(
         config=body.config.model_dump(),
         status="stopped",
     )
+
+    if hasattr(body, 'shared_with_user_ids') and body.shared_with_user_ids is not None:
+        shared_users = db.query(User).filter(User.id.in_(body.shared_with_user_ids)).all()
+        vm.shared_with = shared_users
+
     db.add(vm)
     db.commit()
     db.refresh(vm)
@@ -199,9 +261,7 @@ async def get_vm(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    vm = db.query(VM).filter(VM.id == vm_id, VM.user_id == current_user.id).first()
-    if not vm:
-        raise HTTPException(404, "VM not found")
+    vm = _get_accessible_vm(db, vm_id, current_user)
     return _vm_to_response(vm)
 
 
@@ -212,6 +272,9 @@ async def update_vm(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    if not current_user.is_admin and not current_user.can_manage_vms:
+        raise HTTPException(403, "No Permission to edit / delete VMs")
+    
     vm = db.query(VM).filter(VM.id == vm_id, VM.user_id == current_user.id).first()
     if not vm:
         raise HTTPException(404, "VM not found")
@@ -240,6 +303,13 @@ async def update_vm(
             _write_86box_config(vm, vm_dir)
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Failed to write config: {e}")
+    
+    if hasattr(body, 'shared_with_user_ids') and body.shared_with_user_ids is not None:
+        if not current_user.is_admin and vm.user_id != current_user.id:
+            raise HTTPException(403, "Only the owner can share this VM")
+        
+        shared_users = db.query(User).filter(User.id.in_(body.shared_with_user_ids)).all()
+        vm.shared_with = shared_users
 
     db.commit()
     db.refresh(vm)
@@ -252,6 +322,9 @@ async def delete_vm(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    if not current_user.is_admin and not current_user.can_manage_vms:
+        raise HTTPException(403, "No Permission to edit / delete VMs")
+    
     vm = db.query(VM).filter(VM.id == vm_id, VM.user_id == current_user.id).first()
     if not vm:
         raise HTTPException(404, "VM not found")
@@ -275,11 +348,12 @@ async def start_vm(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    vm = db.query(VM).filter(VM.id == vm_id, VM.user_id == current_user.id).first()
-    if not vm:
-        raise HTTPException(404, "VM not found")
+    vm = _get_accessible_vm(db, vm_id, current_user)
     if vm.status in ("running", "paused", "starting"):
         raise HTTPException(400, "VM is already active")
+
+    if vm.locked_by_user_id is not None and vm.locked_by_user_id != current_user.id:
+        raise HTTPException(403, f"VM is currently in use by {vm.locked_by.username}")
 
     # Enforce active VM limit (DB setting takes priority over runner default)
     raw_limit = db.query(SystemSetting).filter(SystemSetting.key == "active_vm_limit").first()
@@ -306,12 +380,14 @@ async def start_vm(
 
     # Claim the slot immediately so concurrent requests can't bypass the limit
     vm.status = "starting"
+    vm.locked_by_user_id = current_user.id
     db.commit()
 
     service = VMService()
     result = await service.start_vm(vm_id, vm_dir, network_group_id=network_group_id)
     if result.get("error"):
         vm.status = "stopped"
+        vm.locked_by_user_id = None
         db.commit()
         raise HTTPException(500, result["error"])
 
@@ -330,9 +406,10 @@ async def stop_vm(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    vm = db.query(VM).filter(VM.id == vm_id, VM.user_id == current_user.id).first()
-    if not vm:
-        raise HTTPException(404, "VM not found")
+    vm = _get_accessible_vm(db, vm_id, current_user)
+    if vm.locked_by_user_id != current_user.id and not current_user.is_admin:
+        raise HTTPException(403, "You cannot stop a VM started by another user")
+
     if vm.status not in ("running", "paused"):
         raise HTTPException(400, "VM is not running")
 
@@ -340,6 +417,7 @@ async def stop_vm(
     await service.stop_vm(vm_id)
 
     vm.status = "stopped"
+    vm.locked_by_user_id = None
     vm.vnc_port = None
     vm.ws_port = None
     vm.last_stopped = datetime.utcnow()
@@ -411,21 +489,21 @@ async def get_vm_status(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    vm = db.query(VM).filter(VM.id == vm_id, VM.user_id == current_user.id).first()
-    if not vm:
-        raise HTTPException(404, "VM not found")
+    vm = _get_accessible_vm(db, vm_id, current_user)
 
-    # Check actual runner status
+    if vm.status == "stopped" and vm.locked_by_user_id is not None:
+        vm.locked_by_user_id = None
+        db.commit()
+
     service = VMService()
     runner_status = await service.get_vm_status(vm_id)
     actual_status = runner_status.get("status", "stopped")
 
     if actual_status != vm.status:
-        # Don't downgrade "starting" → "stopped": the runner may not have registered
-        # the VM yet. Let the start_vm endpoint own that transition.
         if not (vm.status == "starting" and actual_status == "stopped"):
             vm.status = actual_status
             if actual_status == "stopped":
+                vm.locked_by_user_id = None
                 vm.vnc_port = None
                 vm.ws_port = None
                 vm.last_stopped = datetime.utcnow()
@@ -437,6 +515,7 @@ async def get_vm_status(
         "vnc_port": vm.vnc_port,
         "ws_port": vm.ws_port,
         "uptime": runner_status.get("uptime"),
+        "locked_by_user_id": vm.locked_by_user_id
     }
 
 

--- a/backend/app/routers/vms.py
+++ b/backend/app/routers/vms.py
@@ -530,6 +530,12 @@ def _write_86box_config(vm: VM, vm_dir: str, config_override: dict | None = None
         if isinstance(v, float) and v == int(v):
             return str(int(v))
         return str(v)
+    def _resolve_media(fn: str) -> str:
+        if not fn:
+            return ""
+        if os.path.isabs(fn):
+            return fn
+        return os.path.join(vm_dir, fn)
 
     # ── [Machine] ──────────────────────────────────────────────────────────────
     section("Machine")
@@ -685,7 +691,7 @@ def _write_86box_config(vm: VM, vm_dir: str, config_override: dict | None = None
             opt(f"fdd_{n}_check_bpb", 0)
         fn = cfg.get(f"fdd_{n}_fn", "")
         if fn and ftype != "none":
-            opt(f"fdd_{n}_fn", fn)
+            opt(f"fdd_{n}_fn", _resolve_media(fn))
 
     # CD-ROM drives 01-04
     _default_cdrom_channels = {1: "1:0", 2: "1:1", 3: "2:0", 4: "2:1"}
@@ -706,7 +712,7 @@ def _write_86box_config(vm: VM, vm_dir: str, config_override: dict | None = None
                 opt(f"cdrom_{n}_ide_channel", channel)
             fn = cfg.get(f"cdrom_{n}_fn", "")
             if fn:
-                opt(f"cdrom_{n}_image_path", fn)
+                opt(f"cdrom_{n}_image_path", _resolve_media(fn))
 
     # ── [Ports (COM & LPT)] ───────────────────────────────────────────────────
     section("Ports (COM & LPT)")

--- a/backend/app/routers/vms.py
+++ b/backend/app/routers/vms.py
@@ -502,16 +502,7 @@ def _write_86box_config(vm: VM, vm_dir: str, config_override: dict | None = None
     config_override: optional key/value pairs merged into cfg at write time
     (not persisted to DB). Used e.g. to inject PCap transport for group networking.
     """
-    from ..hardware_lists import get_cpu_by_index, machine_has_builtin_video, get_cdrom_drive_types
-    _cdrom_drive_list = get_cdrom_drive_types()
-    def _cdrom_type_index(internal_name: str) -> int | None:
-        """Map a cdrom_drive_type internal_name to its numeric 86Box index."""
-        if not internal_name:
-            return None
-        for idx, d in enumerate(_cdrom_drive_list):
-            if d.get("internal_name") == internal_name:
-                return idx
-        return None
+    from ..hardware_lists import get_cpu_by_index, machine_has_builtin_video
 
     cfg = dict(vm.config or {})
     if config_override:
@@ -698,9 +689,9 @@ def _write_86box_config(vm: VM, vm_dir: str, config_override: dict | None = None
             speed = cfg.get(f"cdrom_{n}_speed", 24)
             if speed != 24:
                 opt(f"cdrom_{n}_speed", speed)
-            drive_type_idx = _cdrom_type_index(cfg.get(f"cdrom_{n}_drive_type", ""))
-            if drive_type_idx is not None:
-                opt(f"cdrom_{n}_type", drive_type_idx)
+            drive_type = cfg.get(f"cdrom_{n}_drive_type", "")
+            if drive_type:
+                opt(f"cdrom_{n}_type", drive_type)
             if bus_str == "atapi":
                 channel = cfg.get(f"cdrom_{n}_ide_channel") or _default_cdrom_channels[i]
                 opt(f"cdrom_{n}_ide_channel", channel)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -28,6 +28,10 @@ class UserBase(BaseModel):
     is_active: bool = True
     max_vms: int = 10
     max_storage_gb: int = 100
+    can_manage_vms: bool = True
+    can_manage_groups: bool = True
+    can_access_library: bool = True
+    can_upload_images: bool = True
 
 class UserCreate(UserBase):
     password: str = Field(..., min_length=8)
@@ -39,6 +43,10 @@ class UserUpdate(BaseModel):
     max_vms: Optional[int] = None
     max_storage_gb: Optional[int] = None
     password: Optional[str] = None
+    can_manage_vms: Optional[bool] = None
+    can_manage_groups: Optional[bool] = None
+    can_access_library: Optional[bool] = None
+    can_upload_images: Optional[bool] = None
 
 class UserResponse(UserBase):
     id: int
@@ -62,13 +70,14 @@ class VMGroupBase(BaseModel):
     network_enabled: bool = False
 
 class VMGroupCreate(VMGroupBase):
-    pass
+    shared_with_user_ids: Optional[List[int]] = []
 
 class VMGroupUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     color: Optional[str] = None
     network_enabled: Optional[bool] = None
+    shared_with_user_ids: Optional[List[int]] = []
 
 class VMGroupResponse(VMGroupBase):
     id: int
@@ -76,6 +85,7 @@ class VMGroupResponse(VMGroupBase):
     created_at: datetime
     vm_count: int = 0
     has_running_vms: bool = False
+    shared_with_user_ids: Optional[List[int]] = []
 
     class Config:
         from_attributes = True
@@ -293,12 +303,16 @@ class VMUpdate(BaseModel):
     description: Optional[str] = None
     group_id: Optional[int] = None
     config: Optional[VMConfig] = None
+    shared_with_user_ids: Optional[List[int]] = None
 
 class VMResponse(VMBase):
     id: int
     uuid: str
     user_id: int
     status: str
+    locked_by_user_id: Optional[int] = None
+    locked_by_username: Optional[str] = None
+    
     vnc_port: Optional[int] = None
     ws_port: Optional[int] = None
     config: Dict[str, Any]
@@ -309,6 +323,7 @@ class VMResponse(VMBase):
     owner_username: Optional[str] = None
     group_name: Optional[str] = None
     group_color: Optional[str] = None
+    shared_with_user_ids: List[int] = []
 
     class Config:
         from_attributes = True

--- a/frontend/src/components/ImagePickerModal.tsx
+++ b/frontend/src/components/ImagePickerModal.tsx
@@ -546,7 +546,8 @@ export default function ImagePickerModal({ kind, currentPath, onSelect, onClear,
               <WritableColumnBrowser
                 tree={imagesTree}
                 kind={kind}
-                onSelect={onSelect ? (node, path) => { onSelect(path); onClose() } : undefined}
+                // FIX: Prepend the correct VM media subdirectory
+                onSelect={onSelect ? (node, path) => { onSelect(`media/images/${path}`); onClose() } : undefined}
               />
             )
           )}
@@ -560,7 +561,8 @@ export default function ImagePickerModal({ kind, currentPath, onSelect, onClear,
               <ColumnBrowser
                 tree={libraryTree}
                 kind={kind}
-                onSelect={onSelect ? (node, path) => { onSelect(path); onClose() } : undefined}
+                // FIX: Prepend the correct VM media subdirectory
+                onSelect={onSelect ? (node, path) => { onSelect(`media/library/${path}`); onClose() } : undefined}
               />
             )
           )}

--- a/frontend/src/components/ImportVMModal.tsx
+++ b/frontend/src/components/ImportVMModal.tsx
@@ -1,0 +1,215 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { X, FolderDown, AlertCircle } from 'lucide-react'
+import { vmApi } from '../lib/api'
+import { clsx } from 'clsx'
+
+interface Props {
+  // Pass the available groups so the user can assign the imported VM to one
+  groups: { id: number; name: string; color: string; network_enabled: boolean }[]
+  onSuccess: (vmId: number) => void
+  onClose: () => void
+}
+
+interface UnregisteredFolder {
+  folder_name: string
+  machine: string
+}
+
+export default function ImportVMModal({ groups, onSuccess, onClose }: Props) {
+  const [loading, setLoading] = useState(true)
+  const [folders, setFolders] = useState<UnregisteredFolder[]>([])
+  const [error, setError] = useState('')
+  const [importing, setImporting] = useState(false)
+
+  // Form State
+  const [selectedFolder, setSelectedFolder] = useState<string>('')
+  const [vmName, setVmName] = useState('')
+  const [description, setDescription] = useState('')
+  const [groupId, setGroupId] = useState<number | null>(null)
+
+  // Fetch the unregistered folders when the modal opens
+  useEffect(() => {
+    async function fetchFolders() {
+      try {
+        const res = await vmApi.getUnregistered()
+        setFolders(res.unregistered)
+        if (res.unregistered.length > 0) {
+          // Pre-select the first folder in the list
+          setSelectedFolder(res.unregistered[0].folder_name)
+          // Auto-fill the VM name with the folder name
+          setVmName(res.unregistered[0].folder_name)
+        }
+      } catch (err: any) {
+        setError(err.message || 'Failed to scan for VM folders.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchFolders()
+  }, [])
+
+  // Auto-update the VM name if the user changes the folder selection (and hasn't typed a custom name yet)
+  function handleFolderSelect(folder: string) {
+    if (vmName === selectedFolder) {
+      setVmName(folder)
+    }
+    setSelectedFolder(folder)
+  }
+
+  async function handleImport() {
+    if (!selectedFolder) {
+      setError('Please select a folder to import.')
+      return
+    }
+    if (!vmName.trim()) {
+      setError('VM name is required.')
+      return
+    }
+
+    setImporting(true)
+    setError('')
+
+    try {
+      const result = await vmApi.importVM({
+        folder_name: selectedFolder,
+        vm_name: vmName,
+        description: description,
+        group_id: groupId,
+      })
+      onSuccess(result.vm.id)
+      onClose()
+    } catch (err: any) {
+      setError(err.message || 'Import failed.')
+      setImporting(false)
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+      <div className="bg-slate-900 border border-slate-700 rounded-xl shadow-2xl w-full max-w-lg flex flex-col overflow-hidden">
+        
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-slate-800 bg-slate-900/50">
+          <div className="flex items-center gap-2">
+            <FolderDown className="w-5 h-5 text-blue-400" />
+            <h2 className="text-base font-semibold text-white">Import VM from Server</h2>
+          </div>
+          <button onClick={onClose} disabled={importing} className="btn-ghost p-1.5 rounded-lg text-slate-400 hover:text-white transition-colors">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6 space-y-5">
+          {loading ? (
+            <div className="flex flex-col items-center justify-center py-8 space-y-3">
+              <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+              <p className="text-sm text-slate-400">Scanning server directory for VMs...</p>
+            </div>
+          ) : folders.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 space-y-3 text-center">
+              <AlertCircle className="w-10 h-10 text-slate-500" />
+              <div>
+                <p className="text-sm font-medium text-slate-300">No unregistered VMs found</p>
+                <p className="text-xs text-slate-500 mt-1 max-w-[280px]">
+                  Drop a VM folder (containing an <code className="bg-slate-800 px-1 rounded text-amber-300">86box.cfg</code>) into the <code className="bg-slate-800 px-1 rounded text-emerald-300">vms/</code> directory on your server.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <>
+              {/* Folder Selection */}
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-slate-300">Select Folder to Import</label>
+                <select 
+                  className="input w-full" 
+                  value={selectedFolder} 
+                  onChange={e => handleFolderSelect(e.target.value)}
+                  disabled={importing}
+                >
+                  {folders.map(f => (
+                    <option key={f.folder_name} value={f.folder_name}>
+                      {f.folder_name} ({f.machine})
+                    </option>
+                  ))}
+                </select>
+                <p className="text-xs text-slate-500">
+                  This folder will be renamed to a unique UUID upon import.
+                </p>
+              </div>
+
+              <hr className="border-slate-800" />
+
+              {/* VM Details */}
+              <div className="space-y-4">
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium text-slate-300">VM Name</label>
+                  <input 
+                    type="text" 
+                    className="input w-full" 
+                    value={vmName} 
+                    onChange={e => setVmName(e.target.value)} 
+                    placeholder="e.g. Windows 95"
+                    disabled={importing}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium text-slate-300">Description (Optional)</label>
+                  <input 
+                    type="text" 
+                    className="input w-full" 
+                    value={description} 
+                    onChange={e => setDescription(e.target.value)} 
+                    placeholder="A brief description of this machine"
+                    disabled={importing}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium text-slate-300">Group (Optional)</label>
+                  <div className="flex items-center gap-2">
+                    {groupId && (() => { const g = groups.find(g => g.id === groupId); return g ? <span className="w-3 h-3 rounded-sm flex-shrink-0" style={{ backgroundColor: g.color }} /> : null })()}
+                    <select 
+                      className="input flex-1" 
+                      value={groupId ?? ''} 
+                      onChange={e => setGroupId(e.target.value ? parseInt(e.target.value) : null)}
+                      disabled={importing}
+                    >
+                      <option value="">No group</option>
+                      {groups.map(g => <option key={g.id} value={g.id}>{g.name}</option>)}
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-6 py-4 border-t border-slate-800 bg-slate-900/50">
+          {error ? (
+            <p className="text-sm text-red-400">{error}</p>
+          ) : (
+            <div /> // Empty div to keep the flex layout balanced
+          )}
+          <div className="flex items-center gap-2">
+            <button onClick={onClose} disabled={importing} className="btn-secondary text-sm">
+              Cancel
+            </button>
+            <button 
+              onClick={handleImport} 
+              disabled={importing || folders.length === 0 || !selectedFolder} 
+              className={clsx("btn-primary text-sm", importing && "opacity-75 cursor-not-allowed")}
+            >
+              {importing ? 'Importing...' : 'Import VM'}
+            </button>
+          </div>
+        </div>
+
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -17,14 +17,28 @@ import { clsx } from 'clsx'
 
 function StatusDot({ status }: { status: string }) {
   const { serverOnline } = useStore()
+
   const effective = serverOnline ? status : 'stopped'
-  const cls = {
-    running: 'status-running',
-    stopped: 'status-stopped',
-    starting: 'status-starting',
-    error: 'status-error',
-  }[effective] || 'status-stopped'
-  return <span className={cls} />
+  
+  const colorClass = {
+    running: 'bg-emerald-500 dark:bg-emerald-400',
+    paused: 'bg-amber-500 dark:bg-amber-400',
+    starting: 'bg-blue-500 dark:bg-blue-400',
+    stopped: 'bg-red-500 dark:bg-red-400',
+    error: 'bg-red-500 dark:bg-red-400',
+  }[effective] || 'bg-slate-400 dark:bg-slate-500'
+
+  const isAnimated = effective === 'running' || effective === 'paused' || effective === 'starting'
+
+  return (
+    <span 
+      className={clsx(
+        colorClass,
+        isAnimated && 'animate-pulse',
+        'w-2 h-2 rounded-full inline-block flex-shrink-0'
+      )} 
+    />
+  )
 }
 
 function useHashRouting() {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -98,7 +98,7 @@ export default function Layout() {
   const navItems = [
     { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { id: 'vms', label: 'Virtual Machines', icon: Monitor },
-    { id: 'media', label: 'Media', icon: Library },
+    ...(currentUser?.is_admin || currentUser?.can_access_library ? [{ id: 'media', label: 'Media', icon: Library }] : []),
     { id: 'hardware', label: 'DB Explorer', icon: Cpu },
     ...(currentUser?.is_admin && authConfig?.user_management ? [{ id: 'users', label: 'Users', icon: Users }] : []),
     { id: 'settings', label: 'Settings', icon: Settings },

--- a/frontend/src/components/VMConfigModal.tsx
+++ b/frontend/src/components/VMConfigModal.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { X, ChevronRight, HardDrive, Monitor, Volume2, Network, Cpu, Settings2, UsbIcon, Upload, Trash2, Disc, Save, FolderOpen, Plus, CloudOff, ServerCog } from 'lucide-react'
 import { VMConfig, HardwareLists, HardwareOption } from '../types'
-import { systemApi, mediaApi, defaultConfig, formatBytes } from '../lib/api'
+import { systemApi, mediaApi, userApi, defaultConfig, formatBytes } from '../lib/api'
 import { useStore } from '../store/useStore'
 import { withBusGroups } from '../lib/busGroups'
 import { clsx } from 'clsx'
@@ -15,8 +15,9 @@ interface Props {
   initialName?: string
   initialDesc?: string
   initialGroupId?: number
-  groups: { id: number; name: string; color: string; network_enabled: boolean }[]
-  onSave: (name: string, desc: string, groupId: number | null, config: VMConfig) => Promise<void>
+  groups: { id: number; name: string; color: string; network_enabled: boolean; shared_with_user_ids?: number[] }[]
+  initialSharedWith?: number[]
+  onSave: (name: string, desc: string, groupId: number | null, config: VMConfig, sharedWith: number[]) => Promise<void>
   onClose: () => void
   title: string
   readOnly?: boolean
@@ -290,13 +291,15 @@ function hddBusLimits(bus: string): {maxCyl: number, maxHeads: number, maxSpt: n
   return { maxCyl: 266305, maxHeads: 255, maxSpt: 255 }
 }
 
-export default function VMConfigModal({ vmId, initialConfig, initialName = '', initialDesc = '', initialGroupId, groups, onSave, onClose, title, readOnly = false }: Props) {
+export default function VMConfigModal({ vmId, initialConfig, initialName = '', initialDesc = '', initialGroupId, groups, onSave, onClose, title, readOnly = false, initialSharedWith }: Props) {
   const qc = useQueryClient()
   const [activeTab, setActiveTab] = useState<Tab>('general')
   const [name, setName] = useState(initialName)
   const [desc, setDesc] = useState(initialDesc)
   const [groupId, setGroupId] = useState<number | null>(initialGroupId ?? null)
   const [cfg, setCfg] = useState<VMConfig>(initialConfig || defaultConfig())
+  const [sharedWith, setSharedWith] = useState<number[]>(initialSharedWith || [])
+  const { currentUser } = useStore()
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const [uploading, setUploading] = useState(false)
@@ -305,6 +308,11 @@ export default function VMConfigModal({ vmId, initialConfig, initialName = '', i
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [imagePicker, setImagePicker] = useState<{ key: string; kind: 'floppy' | 'cdrom' } | null>(null)
   const { serverOnline, setActiveUpload, updateUploadProgress } = useStore()
+  const { data: users = [] } = useQuery({ 
+    queryKey: ['users'], 
+    queryFn: userApi.list,
+    enabled: !!currentUser?.is_admin 
+  })
 
   const { data: hw } = useQuery({ queryKey: ['hardware'], queryFn: systemApi.hardware })
   const { data: voodooTypes } = useQuery({ queryKey: ['voodoo-types'], queryFn: systemApi.voodooTypes })
@@ -691,7 +699,7 @@ export default function VMConfigModal({ vmId, initialConfig, initialName = '', i
     setSaving(true)
     setError('')
     try {
-      await onSave(name, desc, groupId, cfg)
+      await onSave(name, desc, groupId, cfg, sharedWith)
       onClose()
     } catch (e: any) {
       setError(e.message || 'Save failed')
@@ -784,6 +792,67 @@ export default function VMConfigModal({ vmId, initialConfig, initialName = '', i
                       <p className="text-xs text-slate-400 mt-1">No networking — VMs in this group are isolated</p>
                     ) : null })()}
                   </Field>
+                  <FieldGroup label="Sharing">
+                  <Field label="Shared with user" hint="Select users who can access this VM">
+                    {(() => {
+                      const selectedGroup = groups.find(g => g.id === groupId);
+                      const isGroupShared = selectedGroup && selectedGroup.shared_with_user_ids && selectedGroup.shared_with_user_ids.length > 0;
+                      const effectiveSharedWith = isGroupShared ? selectedGroup.shared_with_user_ids! : sharedWith;
+
+                      if (isGroupShared) {
+                        return (
+                          <div className="space-y-3">
+                            <p className="text-xs text-amber-500 dark:text-amber-400 font-medium">
+                              Permissions are inherited from the group "{selectedGroup.name}". 
+                              To assign specific permissions, remove this VM from the group first.
+                            </p>
+                            <div className="flex flex-wrap gap-2 opacity-60 pointer-events-none">
+                              {users.filter(u => effectiveSharedWith.includes(u.id)).map(u => (
+                                <span key={u.id} className="inline-flex items-center gap-1.5 bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 px-2.5 py-1 rounded-md text-sm font-medium">
+                                  {u.username}
+                                </span>
+                              ))}
+                            </div>
+                          </div>
+                        );
+                      }
+
+                      if (!currentUser?.is_admin) {
+                        return <p className="text-xs text-slate-500 mt-2">Only Admins can share VMs.</p>;
+                      }
+
+                      return (
+                        <div className="space-y-3">
+                          <div className="flex flex-wrap gap-2">
+                            {users.filter(u => sharedWith.includes(u.id)).map(u => (
+                              <span key={u.id} className="inline-flex items-center gap-1.5 bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 px-2.5 py-1 rounded-md text-sm font-medium">
+                                {u.username}
+                                <button type="button" onClick={() => setSharedWith(sharedWith.filter(id => id !== u.id))} className="hover:text-red-500 focus:outline-none transition-colors">
+                                  <X className="w-3.5 h-3.5" />
+                                </button>
+                              </span>
+                            ))}
+                            {sharedWith.length === 0 && <span className="text-sm text-slate-500 italic">Not shared with any user.</span>}
+                          </div>
+                          {users.filter(u => u.id !== currentUser.id && !sharedWith.includes(u.id)).length > 0 && (
+                            <select
+                              className="input w-full text-sm"
+                              value=""
+                              onChange={e => {
+                                if (e.target.value) setSharedWith([...sharedWith, parseInt(e.target.value)])
+                              }}
+                            >
+                              <option value="">+ Add another user...</option>
+                              {users.filter(u => u.id !== currentUser.id && !sharedWith.includes(u.id)).map(u => (
+                                <option key={u.id} value={u.id}>{u.username}</option>
+                              ))}
+                            </select>
+                          )}
+                        </div>
+                      );
+                    })()}
+                  </Field>
+                </FieldGroup>
                 </FieldGroup>
               </>
             )}

--- a/frontend/src/components/VNCViewer.tsx
+++ b/frontend/src/components/VNCViewer.tsx
@@ -7,6 +7,7 @@ import { VMConfig } from '../types'
 import VMConfigModal from './VMConfigModal'
 import ImagePickerModal from './ImagePickerModal'
 import ConfirmDialog from './ConfirmDialog'
+import { clsx } from 'clsx'
 
 interface Props {
   vmId: number
@@ -19,6 +20,7 @@ export default function VNCViewer({ vmId, vmName }: Props) {
   const canvasRef = useRef<HTMLDivElement>(null)
   const rfbRef = useRef<any>(null)
   const audioRef = useRef<HTMLAudioElement>(null)
+  const keyboardInputRef = useRef<HTMLTextAreaElement>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [muted, setMuted] = useState(true)  // start muted so autoplay is allowed
@@ -35,6 +37,57 @@ export default function VNCViewer({ vmId, vmName }: Props) {
   // 86Box starts in fullscreen with its UI (menu+status bar) hidden.
   // This tracks whether the user has toggled it back on.
   const [uiVisible, setUiVisible] = useState(false)
+  const [keyboardActive, setKeyboardActive] = useState(false)
+
+  const handleHiddenInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const val = e.target.value
+    if (!val || !rfbRef.current) return
+    
+    for (const char of val) {
+      const code = char.charCodeAt(0)
+      rfbRef.current.sendKey(code, char, true)
+      rfbRef.current.sendKey(code, char, false)
+    }
+    e.target.value = ''
+  }
+
+  const handleHiddenKeyDown = (e: React.KeyboardEvent) => {
+    if (!rfbRef.current) return
+    
+    const keyMap: Record<string, number> = {
+      'Backspace': 0xff08,
+      'Enter': 0xff0d,
+      'Tab': 0xff09,
+      'Escape': 0xff1b,
+      'ArrowUp': 0xff52,
+      'ArrowDown': 0xff54,
+      'ArrowLeft': 0xff51,
+      'ArrowRight': 0xff53,
+    }
+
+    if (keyMap[e.key]) {
+      rfbRef.current.sendKey(keyMap[e.key], e.key, true)
+      rfbRef.current.sendKey(keyMap[e.key], e.key, false)
+      e.preventDefault()
+    }
+  }
+
+  const toggleKeyboard = () => {
+    if (keyboardActive) {
+      keyboardInputRef.current?.blur()
+    } else {
+      keyboardInputRef.current?.focus()
+    }
+  }
+
+  const sendSpecialKey = (keysym: number, name: string) => {
+    if (rfbRef.current) {
+      rfbRef.current.sendKey(keysym, name, true)
+      setTimeout(() => {
+        rfbRef.current?.sendKey(keysym, name, false)
+      }, 50) // Short delay so that the VM registers the input
+    }
+  }
 
   // 86Box keybindings — locked to defaults in 86box_global.cfg at runner startup.
   const KEY_TOGGLE_UI  = 'ctrl+alt+Next'   // Ctrl+Alt+PgDown — Toggle UI in fullscreen
@@ -461,6 +514,23 @@ export default function VNCViewer({ vmId, vmName }: Props) {
             </button>
           )}
 
+          {/* Virtual Keyboard Toggle for Mobile / Tablets */}
+          {isRunning && serverOnline && (
+            <button
+              onClick={toggleKeyboard}
+              onMouseDown={(e) => e.preventDefault()}
+              title="Toggle virtual keyboard"
+              className={clsx(
+                "btn-ghost text-xs transition-colors",
+                keyboardActive 
+                  ? "text-blue-500 bg-blue-50 dark:bg-blue-900/30" 
+                  : "text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"
+              )}
+            >
+              <Keyboard className="w-3.5 h-3.5" />
+            </button>
+          )}
+
           {/* Toggle 86Box UI (menu + status bar) — only when running */}
           {isRunning && serverOnline && (
             <button
@@ -580,6 +650,45 @@ export default function VNCViewer({ vmId, vmName }: Props) {
       <div className="flex-1 relative bg-black">
         <div ref={canvasRef} className={`absolute inset-0 ${scaleToFit ? 'overflow-hidden' : 'overflow-auto'}`} />
 
+        {keyboardActive && isRunning && (
+          <div 
+            className="absolute top-2 right-2 flex flex-col gap-1.5 p-2 bg-slate-900/80 backdrop-blur-md border border-slate-700 rounded-xl z-50 shadow-2xl"
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            {/* Upper Bar: F1-F12 */}
+            <div className="flex justify-end gap-1.5">
+              {[1,2,3,4,5,6,7,8,9,10,11,12].map(num => (
+                <button 
+                  key={num} 
+                  onClick={() => sendSpecialKey(0xffbe + num - 1, `F${num}`)} 
+                  className="px-2 py-1 bg-slate-700 text-white rounded text-[10px] hover:bg-slate-600 transition-colors"
+                >
+                  F{num}
+                </button>
+              ))}
+            </div>
+
+            <div className="w-full h-px bg-slate-700 my-0.5" />
+
+            {/* Lower Bar: Special Keys and Arrow Keys */}
+            <div className="flex justify-end gap-1.5">
+              <button onClick={() => sendSpecialKey(0xff1b, 'Escape')} className="px-2 py-1 bg-slate-800 text-white rounded text-[10px] font-bold hover:bg-slate-700 transition-colors">ESC</button>
+              <button onClick={() => sendSpecialKey(0xff09, 'Tab')} className="px-2 py-1 bg-slate-800 text-white rounded text-[10px] font-bold hover:bg-slate-700 transition-colors">TAB</button>
+              <button onClick={() => sendSpecialKey(0xffe3, 'Control')} className="px-2 py-1 bg-slate-800 text-white rounded text-[10px] font-bold hover:bg-slate-700 transition-colors">CTRL</button>
+              <button onClick={() => sendSpecialKey(0xffeb, 'Meta')} className="px-2 py-1 bg-slate-800 text-white rounded text-[10px] font-bold hover:bg-slate-700 transition-colors">WIN</button>
+              <button onClick={() => sendSpecialKey(0xffe9, 'Alt')} className="px-2 py-1 bg-slate-800 text-white rounded text-[10px] font-bold hover:bg-slate-700 transition-colors">ALT</button>
+              <button onClick={() => sendSpecialKey(0xffff, 'Delete')} className="px-2 py-1 bg-red-900/60 text-white rounded text-[10px] font-bold hover:bg-red-800 transition-colors">DEL</button>
+              
+              <div className="w-px h-5 bg-slate-700 mx-1 self-center" />
+              
+              <button onClick={() => sendSpecialKey(0xff51, 'ArrowLeft')} className="px-2 py-1 bg-slate-800 text-white rounded text-[10px] hover:bg-slate-700 transition-colors">◀</button>
+              <button onClick={() => sendSpecialKey(0xff52, 'ArrowUp')} className="px-2 py-1 bg-slate-800 text-white rounded text-[10px] hover:bg-slate-700 transition-colors">▲</button>
+              <button onClick={() => sendSpecialKey(0xff54, 'ArrowDown')} className="px-2 py-1 bg-slate-800 text-white rounded text-[10px] hover:bg-slate-700 transition-colors">▼</button>
+              <button onClick={() => sendSpecialKey(0xff53, 'ArrowRight')} className="px-2 py-1 bg-slate-800 text-white rounded text-[10px] hover:bg-slate-700 transition-colors">▶</button>
+            </div>
+          </div>
+        )}
+
         {loading && isRunning && (
           <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/80 text-slate-300">
             <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin mb-3" />
@@ -684,6 +793,21 @@ export default function VNCViewer({ vmId, vmName }: Props) {
           }}
         />
       )}
+
+      {/* Hidden textarea with enhanced event listeners */}
+      <textarea
+        ref={keyboardInputRef}
+        className="absolute opacity-0 p-0 w-0 h-0 pointer-events-none"
+        style={{ top: '-100px', left: '-100px' }}
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+        onFocus={() => setKeyboardActive(true)}
+        onBlur={() => setKeyboardActive(false)}
+        onChange={handleHiddenInput}
+        onKeyDown={handleHiddenKeyDown}
+      />
+
     </div>
   )
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -62,10 +62,10 @@ export const vmApi = {
 
   get: (id: number) => request<VM>(`/vms/${id}`),
 
-  create: (data: { name: string; description?: string; group_id?: number; config: VMConfig }) =>
+  create: (data: { name: string; description?: string; group_id?: number; config: VMConfig; shared_with_user_ids?: number[] }) =>
     request<VM>('/vms', { method: 'POST', body: JSON.stringify(data) }),
 
-  update: (id: number, data: { name?: string; description?: string; group_id?: number | null; config?: VMConfig }) =>
+  update: (id: number, data: { name?: string; description?: string; group_id?: number | null; config?: VMConfig; shared_with_user_ids?: number[] }) =>
     request<VM>(`/vms/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
 
   delete: (id: number) => request<void>(`/vms/${id}`, { method: 'DELETE' }),
@@ -75,7 +75,16 @@ export const vmApi = {
   reset: (id: number) => request<{ status: string }>(`/vms/${id}/reset`, { method: 'POST' }),
   pause: (id: number) => request<{ status: string }>(`/vms/${id}/pause`, { method: 'POST' }),
   sendKey: (id: number, key: string) => request<{ status: string }>(`/vms/${id}/send-key`, { method: 'POST', body: JSON.stringify({ key }) }),
-  status: (id: number) => request<{ id: number; status: string; vnc_port?: number; ws_port?: number; uptime?: number }>(`/vms/${id}/status`),
+  status: (id: number) => request<{ id: number; status: string; vnc_port?: number; ws_port?: number; uptime?: number; locked_by_user_id?: number | null; locked_by_username?: string | null }>(`/vms/${id}/status`),
+
+  getUnregistered: () => 
+    request<{ unregistered: { folder_name: string; machine: string }[] }>('/vms/unregistered'),
+  
+  importVM: (data: { folder_name: string; vm_name: string; description?: string; group_id: number | null }) => 
+    request<{ vm: VM }>('/vms/import', { 
+      method: 'POST', 
+      body: JSON.stringify(data) 
+    }),
 
   mountDrive: (id: number, driveKey: string, path: string) =>
     request<{ status: string; drive_key: string; path: string }>(
@@ -92,9 +101,9 @@ export const vmApi = {
 
   // Groups
   listGroups: () => request<VMGroup[]>('/vms/groups'),
-  createGroup: (data: { name: string; description?: string; color: string; network_enabled?: boolean }) =>
+  createGroup: (data: { name: string; description?: string; color: string; network_enabled?: boolean; shared_with_user_ids?: number[] }) =>
     request<VMGroup>('/vms/groups', { method: 'POST', body: JSON.stringify(data) }),
-  updateGroup: (id: number, data: Partial<{ name: string; description: string; color: string; network_enabled: boolean }>) =>
+  updateGroup: (id: number, data: Partial<{ name: string; description: string; color: string; network_enabled: boolean; shared_with_user_ids: number[] }>) =>
     request<VMGroup>(`/vms/groups/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
   deleteGroup: (id: number) => request<void>(`/vms/groups/${id}`, { method: 'DELETE' }),
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -62,6 +62,17 @@ export const vmApi = {
 
   get: (id: number) => request<VM>(`/vms/${id}`),
 
+  // NEW: Fetches the list of VM folders that exist in vms/ but are not yet registered in the database
+  getUnregistered: () => 
+    request<{ unregistered: { folder_name: string; machine: string }[] }>('/vms/unregistered'),
+
+  // NEW: Sends the command to import one of these discovered folders as a new VM
+  importVM: (data: { folder_name: string; vm_name: string; description?: string; group_id?: number | null }) =>
+    request<{ status: string; vm: { id: number; uuid: string } }>('/vms/import', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+
   create: (data: { name: string; description?: string; group_id?: number; config: VMConfig }) =>
     request<VM>('/vms', { method: 'POST', body: JSON.stringify(data) }),
 

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -5,6 +5,7 @@ import { Plus, Pencil, Trash2, Shield, User as UserIcon, CheckCircle, XCircle } 
 import { userApi, formatBytes } from '../lib/api'
 import { useStore } from '../store/useStore'
 import { User } from '../types'
+import { clsx } from 'clsx'
 import ConfirmDialog from '../components/ConfirmDialog'
 
 function UserModal({ initial, onSave, onClose }: {
@@ -22,6 +23,10 @@ function UserModal({ initial, onSave, onClose }: {
     is_active: initial?.is_active !== false,
     max_vms: initial?.max_vms ?? 10,
     max_storage_gb: initial?.max_storage_gb ?? 100,
+    can_manage_vms: initial?.can_manage_vms ?? true,
+    can_manage_groups: initial?.can_manage_groups ?? true,
+    can_access_library: initial?.can_access_library ?? true,
+    can_upload_images: initial?.can_upload_images ?? true,
   })
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
@@ -100,6 +105,36 @@ function UserModal({ initial, onSave, onClose }: {
             </label>
           </div>
         </div>
+          <div className="border-t border-slate-200 dark:border-slate-800 pt-4 mt-4">
+            <h3 className="text-sm font-medium text-slate-900 dark:text-white mb-3">Permissions</h3>
+            <div className="space-y-3">
+              {[
+                { key: 'can_manage_vms', label: 'Create & Delete VMs', desc: 'Allow user to create, edit and delete Virtual Machines.' },
+                { key: 'can_manage_groups', label: 'Manage Groups', desc: 'Allow user to create and edit VM folders/groups.' },
+                { key: 'can_access_library', label: 'Access Global Library', desc: 'Allow user to see the read-only ISO library.' },
+                { key: 'can_upload_images', label: 'Upload Images', desc: 'Allow user to upload custom ISOs and floppy images.' },
+              ].map(perm => (
+                <div key={perm.key} className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className={`text-sm font-medium text-slate-700 dark:text-slate-300 ${form.is_admin ? 'opacity-50' : ''}`}>{perm.label}</p>
+                    <p className={`text-xs text-slate-500 mt-0.5 ${form.is_admin ? 'opacity-50' : ''}`}>{perm.desc}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setForm(f => ({ ...f, [perm.key]: !(f as any)[perm.key] }))}
+                    disabled={form.is_admin}
+                    className={clsx(
+                      'flex-shrink-0 relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none',
+                      form.is_admin ? 'bg-blue-300 dark:bg-blue-900/50 cursor-not-allowed' : (form as any)[perm.key] ? 'bg-blue-600' : 'bg-slate-300 dark:bg-slate-600',
+                    )}
+                    title={form.is_admin ? 'Admins always have all permissions' : undefined}
+                  >
+                    <span className={clsx('inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform', (form.is_admin || (form as any)[perm.key]) ? 'translate-x-6' : 'translate-x-1')} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
         {error && <p className="text-sm text-red-500 mt-3">{error}</p>}
         <div className="flex gap-3 mt-6 justify-end">
           <button onClick={onClose} className="btn-secondary">Cancel</button>

--- a/frontend/src/pages/VMsPage.tsx
+++ b/frontend/src/pages/VMsPage.tsx
@@ -3,13 +3,14 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   Plus, Play, Square, RotateCcw, Pencil, Trash2, Monitor, Loader2,
   FolderPlus, ChevronDown, ChevronRight, LayoutGrid, List,
-  HardDrive, Eye, Network, Settings2, CloudOff,
+  HardDrive, Eye, Network, Settings2, CloudOff, FolderDown
 } from 'lucide-react'
 import { vmApi, systemApi, formatBytes } from '../lib/api'
 import { VM, VMConfig, VMGroup } from '../types'
 import { useStore } from '../store/useStore'
 import VMConfigModal from '../components/VMConfigModal'
 import ConfirmDialog from '../components/ConfirmDialog'
+import ImportVMModal from '../components/ImportVMModal'
 import { clsx } from 'clsx'
 
 type ViewMode = 'grid' | 'list'
@@ -404,6 +405,7 @@ export default function VMsPage() {
   const { addToast, authConfig, serverOnline, openTabs, updateTabGroupColor } = useStore()
   const [view, setView] = useState<ViewMode>('grid')
   const [showCreateVM, setShowCreateVM] = useState(false)
+  const [showImportVM, setShowImportVM] = useState(false)
   const [editVM, setEditVM] = useState<VM | null>(null)
   const [showCreateGroup, setShowCreateGroup] = useState(false)
   const [editGroup, setEditGroup] = useState<VMGroup | null>(null)
@@ -550,6 +552,17 @@ export default function VMsPage() {
           </button>
           <button
             disabled={!serverOnline}
+            onClick={() => atVMQuota ? addToast(`VM quota reached (${userStats!.max_vms} VMs). Delete a VM to import a new one.`, 'error') : setShowImportVM(true)}
+            className={clsx(
+              'flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg text-white bg-amber-500 hover:bg-amber-600 shadow-sm transition-colors', 
+              (atVMQuota || !serverOnline) && 'opacity-60 cursor-not-allowed'
+            )}
+            title={!serverOnline ? 'Server unavailable' : atVMQuota ? `Quota reached: ${userStats?.max_vms} VMs` : undefined}
+          >
+            <FolderDown className="w-4 h-4" />Import VM
+          </button>
+          <button
+            disabled={!serverOnline}
             onClick={() => atVMQuota ? addToast(`VM quota reached (${userStats!.max_vms} VMs). Delete a VM to create a new one.`, 'error') : setShowCreateVM(true)}
             className={clsx('btn-primary', (atVMQuota || !serverOnline) && 'opacity-60')}
             title={!serverOnline ? 'Server unavailable' : atVMQuota ? `Quota reached: ${userStats?.max_vms} VMs` : undefined}
@@ -644,6 +657,19 @@ export default function VMsPage() {
           onClose={() => setShowCreateVM(false)}
           onSave={async (name, desc, groupId, config) => {
             await createVMMut.mutateAsync({ name, description: desc, group_id: groupId ?? undefined, config })
+          }}
+        />
+      )}
+
+      {/* Import VM modal */}
+      {showImportVM && (
+        <ImportVMModal
+          groups={groups}
+          onClose={() => setShowImportVM(false)}
+          onSuccess={(vmId) => {
+             // Invalidate the cache to reload the VM list automatically
+             qc.invalidateQueries({ queryKey: ['vms'] })
+             addToast('VM successfully imported!', 'success')
           }}
         />
       )}

--- a/frontend/src/pages/VMsPage.tsx
+++ b/frontend/src/pages/VMsPage.tsx
@@ -402,7 +402,14 @@ function GroupSection({ group, vms, view, onEditVM, collapsed, onToggle, cpuSpee
 export default function VMsPage() {
   const qc = useQueryClient()
   const { addToast, authConfig, serverOnline, openTabs, updateTabGroupColor } = useStore()
-  const [view, setView] = useState<ViewMode>('grid')
+  const [view, setView] = useState<ViewMode>(() => {
+    const savedMode = localStorage.getItem('vmViewPreference');
+    return (savedMode === 'grid' || savedMode === 'list') ? savedMode : 'grid';
+  });
+
+  useEffect(() => {
+    localStorage.setItem('vmViewPreference', view);
+  }, [view]);
   const [showCreateVM, setShowCreateVM] = useState(false)
   const [editVM, setEditVM] = useState<VM | null>(null)
   const [showCreateGroup, setShowCreateGroup] = useState(false)

--- a/frontend/src/pages/VMsPage.tsx
+++ b/frontend/src/pages/VMsPage.tsx
@@ -3,14 +3,15 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   Plus, Play, Square, RotateCcw, Pencil, Trash2, Monitor, Loader2,
   FolderPlus, ChevronDown, ChevronRight, LayoutGrid, List,
-  HardDrive, Eye, Network, Settings2, CloudOff,
+  HardDrive, Eye, Network, Settings2, CloudOff, Users, ArrowUp, ArrowDown
 } from 'lucide-react'
-import { vmApi, systemApi, formatBytes } from '../lib/api'
+import { vmApi, systemApi, formatBytes, userApi } from '../lib/api'
 import { VM, VMConfig, VMGroup } from '../types'
 import { useStore } from '../store/useStore'
 import VMConfigModal from '../components/VMConfigModal'
 import ConfirmDialog from '../components/ConfirmDialog'
 import { clsx } from 'clsx'
+import { X } from 'lucide-react'
 
 type ViewMode = 'grid' | 'list'
 
@@ -29,11 +30,51 @@ function StatusBadge({ status }: { status: string }) {
   )
 }
 
-function VMCard({ vm, onEdit, groupColor, cpuSpeeds, onStartError }: { vm: VM; onEdit: () => void; groupColor?: string; cpuSpeeds?: Record<string, string[]>; onStartError?: (msg: string) => void }) {
+function SharedBadge({ isSharedWithMe, ownerName, sharedCount, asBadge = false }: { isSharedWithMe: boolean, ownerName?: string, sharedCount: number, asBadge?: boolean }) {
+  if (!isSharedWithMe && sharedCount === 0) return null;
+
+  const tooltip = isSharedWithMe
+    ? `Shared from ${ownerName || 'another user'}`
+    : `Shared with ${sharedCount} user${sharedCount !== 1 ? 's' : ''}`;
+
+  const content = (
+    <>
+      <Users className={asBadge ? "w-3 h-3" : "w-3.5 h-3.5"} />
+      {isSharedWithMe 
+        ? <ArrowDown className={asBadge ? "w-2.5 h-2.5 -ml-0.5" : "w-3 h-3 -ml-0.5"} /> 
+        : <ArrowUp className={asBadge ? "w-2.5 h-2.5 -ml-0.5" : "w-3 h-3 -ml-0.5"} />
+      }
+      {asBadge && <span className="ml-0.5">Shared</span>}
+    </>
+  );
+
+  if (asBadge) {
+    return (
+      <span className="flex-shrink-0 flex items-center text-xs text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 px-1.5 py-0.5 rounded cursor-help border border-indigo-100 dark:border-indigo-800/50" title={tooltip}>
+        {content}
+      </span>
+    );
+  }
+
+  return (
+    <span className="flex items-center text-indigo-500 dark:text-indigo-400 bg-indigo-50/50 dark:bg-indigo-900/30 px-1.5 py-0.5 rounded-md cursor-help transition-colors border border-transparent hover:border-indigo-200 dark:hover:border-indigo-800" title={tooltip}>
+      {content}
+    </span>
+  );
+}
+
+function VMCard({ vm, parentGroup, onEdit, groupColor, cpuSpeeds, onStartError }: { vm: VM; parentGroup?: VMGroup; onEdit: () => void; groupColor?: string; cpuSpeeds?: Record<string, string[]>; onStartError?: (msg: string) => void }) {
   const qc = useQueryClient()
-  const { openVMTab, closeVMTab, addToast, serverOnline } = useStore()
+  const { currentUser, openVMTab, closeVMTab, addToast, serverOnline } = useStore()
+  
+  const effectiveSharedIds = parentGroup?.shared_with_user_ids?.length ? parentGroup.shared_with_user_ids : (vm.shared_with_user_ids || []);
+  const isSharedWithMe = effectiveSharedIds.includes(currentUser?.id || 0) || false;
+  const sharedCount = effectiveSharedIds.length || 0;
+  
+  const isOwnerOrAdmin = currentUser?.is_admin || currentUser?.username === vm.owner_username;
   const isRunning = serverOnline && (vm.status === 'running' || vm.status === 'paused' || vm.status === 'starting')
   const [deleteConfirm, setDeleteConfirm] = useState(false)
+  const isLockedByOther = !!vm.locked_by_user_id && vm.locked_by_user_id !== currentUser?.id;
 
   const startMut = useMutation({
     mutationFn: () => {
@@ -81,7 +122,10 @@ function VMCard({ vm, onEdit, groupColor, cpuSpeeds, onStartError }: { vm: VM; o
           <h3 className="font-semibold text-slate-900 dark:text-white text-sm truncate cursor-pointer hover:text-blue-600 dark:hover:text-blue-400" onClick={() => openVMTab({ vmId: vm.id, vmUuid: vm.uuid, vmName: vm.name, status: vm.status, group_color: vm.group_color })}>{vm.name}</h3>
           {vm.description && <p className="text-xs text-slate-400 dark:text-slate-500 truncate mt-0.5" title={vm.description}>{vm.description}</p>}
         </div>
-        <StatusBadge status={vm.status} />
+        <div className="flex flex-col items-end gap-1.5 flex-shrink-0 min-h-[44px]">
+          <StatusBadge status={vm.status} />
+          <SharedBadge isSharedWithMe={isSharedWithMe} ownerName={vm.owner_username} sharedCount={sharedCount} />
+        </div>
       </div>
 
       {/* Specs */}
@@ -110,15 +154,21 @@ function VMCard({ vm, onEdit, groupColor, cpuSpeeds, onStartError }: { vm: VM; o
 
       {/* Actions */}
       <div className="flex items-center gap-2 border-t border-slate-100 dark:border-slate-800 pt-3 mt-auto">
-        {isRunning ? (
+        {isLockedByOther && !currentUser?.is_admin ? (
+          <button disabled className="btn-secondary flex-1 justify-center text-xs py-1.5 opacity-60 cursor-not-allowed border-amber-200 text-amber-700 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-800 dark:text-amber-400">
+            🔒 In use by {vm.locked_by_username}
+          </button>
+        ) : isRunning ? (
           <>
-            <button onClick={() => openVMTab({ vmId: vm.id, vmUuid: vm.uuid, vmName: vm.name, status: vm.status, group_color: vm.group_color })} className="btn-primary flex-1 justify-center text-xs py-1.5">
-              <Monitor className="w-3.5 h-3.5" />Console
+            <button onClick={() => openVMTab({ vmId: vm.id, vmUuid: vm.uuid, vmName: vm.name, status: vm.status, group_color: vm.group_color })} className={clsx("btn-primary flex-1 justify-center text-xs py-1.5", isLockedByOther && "bg-amber-600 hover:bg-amber-700 text-white border-none")}>
+              <Monitor className="w-3.5 h-3.5" />
+              {isLockedByOther ? `Console (🔒 ${vm.locked_by_username})` : 'Console'}
             </button>
             <button onClick={() => stopMut.mutate()} disabled={stopMut.isPending} className="btn-secondary p-2" title="Stop">
               <Square className="w-3.5 h-3.5" />
             </button>
-            <button onClick={onEdit} className="btn-ghost p-2" title="View settings (read-only while running)">
+            
+            <button onClick={onEdit} disabled={!isOwnerOrAdmin} className="btn-ghost p-2 disabled:opacity-40 disabled:cursor-not-allowed" title={!isOwnerOrAdmin ? 'No permission' : 'View settings'}>
               <Eye className="w-3.5 h-3.5" />
             </button>
           </>
@@ -128,15 +178,12 @@ function VMCard({ vm, onEdit, groupColor, cpuSpeeds, onStartError }: { vm: VM; o
               <Play className="w-3.5 h-3.5" />
               {startMut.isPending || startMut.isSuccess ? 'Starting…' : 'Start'}
             </button>
-            <button onClick={onEdit} disabled={!serverOnline} className="btn-ghost p-2 disabled:opacity-40 disabled:cursor-not-allowed" title={serverOnline ? 'Edit' : 'Server unavailable'}>
+            
+            <button onClick={onEdit} disabled={!serverOnline || !isOwnerOrAdmin} className="btn-ghost p-1.5 disabled:opacity-40 disabled:cursor-not-allowed" title={!isOwnerOrAdmin ? 'No permission' : serverOnline ? 'Edit' : 'Server unavailable'}>
               <Pencil className="w-3.5 h-3.5" />
             </button>
-            <button
-              onClick={() => setDeleteConfirm(true)}
-              disabled={!serverOnline}
-              className="btn-ghost p-2 text-red-400 hover:text-red-600 disabled:opacity-40 disabled:cursor-not-allowed"
-              title={serverOnline ? 'Delete' : 'Server unavailable'}
-            >
+            
+            <button onClick={() => setDeleteConfirm(true)} disabled={!serverOnline || !isOwnerOrAdmin} className="btn-ghost p-1.5 text-red-400 disabled:opacity-40 disabled:cursor-not-allowed" title={!isOwnerOrAdmin ? 'No permission' : serverOnline ? undefined : 'Server unavailable'}>
               <Trash2 className="w-3.5 h-3.5" />
             </button>
           </>
@@ -155,10 +202,19 @@ function VMCard({ vm, onEdit, groupColor, cpuSpeeds, onStartError }: { vm: VM; o
   )
 }
 
-function VMRow({ vm, onEdit, groupColor, onStartError }: { vm: VM; onEdit: () => void; groupColor?: string; onStartError?: (msg: string) => void }) {
+function VMRow({ vm, parentGroup, onEdit, groupColor, onStartError }: { vm: VM; parentGroup?: VMGroup; onEdit: () => void; groupColor?: string; onStartError?: (msg: string) => void }) {
   const qc = useQueryClient()
-  const { openVMTab, closeVMTab, addToast, serverOnline } = useStore()
+  const { currentUser, openVMTab, closeVMTab, addToast, serverOnline } = useStore()
+  
+  // Vererbung der Rechte:
+  const effectiveSharedIds = parentGroup?.shared_with_user_ids?.length ? parentGroup.shared_with_user_ids : (vm.shared_with_user_ids || []);
+  const isSharedWithMe = effectiveSharedIds.includes(currentUser?.id || 0) || false;
+  const sharedCount = effectiveSharedIds.length || 0;
+
+  const isOwnerOrAdmin = currentUser?.is_admin || currentUser?.username === vm.owner_username;
+  const isLockedByOther = !!vm.locked_by_user_id && vm.locked_by_user_id !== currentUser?.id;
   const [deleteConfirm, setDeleteConfirm] = useState(false)
+
   const startMut = useMutation({
     mutationFn: () => {
       if (!serverOnline) return Promise.reject(new Error('Server is unreachable. Please wait for the connection to be restored.'))
@@ -194,7 +250,11 @@ function VMRow({ vm, onEdit, groupColor, onStartError }: { vm: VM; onEdit: () =>
             <Monitor className={clsx('w-3.5 h-3.5', isRunning ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-400')} />
           </div>
           <div className="min-w-0">
-            <p className="text-sm font-medium text-slate-900 dark:text-white truncate cursor-pointer hover:text-blue-600 dark:hover:text-blue-400" onClick={() => openVMTab({ vmId: vm.id, vmUuid: vm.uuid, vmName: vm.name, status: vm.status, group_color: vm.group_color })}>{vm.name}</p>
+            {/* VM Name und das SharedBadge nebeneinander */}
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-medium text-slate-900 dark:text-white truncate cursor-pointer hover:text-blue-600 dark:hover:text-blue-400" onClick={() => openVMTab({ vmId: vm.id, vmUuid: vm.uuid, vmName: vm.name, status: vm.status, group_color: vm.group_color })}>{vm.name}</p>
+              <SharedBadge isSharedWithMe={isSharedWithMe} ownerName={vm.owner_username} sharedCount={sharedCount} />
+            </div>
             {vm.description && <p className="text-xs text-slate-400 truncate" title={vm.description}>{vm.description}</p>}
           </div>
         </div>
@@ -206,26 +266,39 @@ function VMRow({ vm, onEdit, groupColor, onStartError }: { vm: VM; onEdit: () =>
       </td>
       <td className="px-5 py-3 w-48">
         <div className="flex items-center gap-1.5">
-          {isRunning ? (
+          {isLockedByOther && !currentUser?.is_admin ? (
+            <button disabled className="btn-secondary flex-1 justify-center text-xs py-1.5 opacity-60 cursor-not-allowed border-amber-200 text-amber-700 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-800 dark:text-amber-400">
+              🔒 In use by {vm.locked_by_username}
+            </button>
+          ) : isRunning ? (
             <>
-              <button onClick={() => openVMTab({ vmId: vm.id, vmUuid: vm.uuid, vmName: vm.name, status: vm.status, group_color: vm.group_color })} className="btn-primary text-xs py-1 px-2.5">
-                <Monitor className="w-3 h-3" />Console
+              <button onClick={() => openVMTab({ vmId: vm.id, vmUuid: vm.uuid, vmName: vm.name, status: vm.status, group_color: vm.group_color })} className={clsx("btn-primary text-xs py-1 px-2.5", isLockedByOther && "bg-amber-600 hover:bg-amber-700 text-white border-none")}>
+                <Monitor className="w-3 h-3" />
+                {isLockedByOther ? `Console (🔒 ${vm.locked_by_username})` : 'Console'}
               </button>
-              <button onClick={() => stopMut.mutate()} disabled={stopMut.isPending} className="btn-secondary text-xs py-1 px-2 disabled:opacity-60">
+              <button onClick={() => stopMut.mutate()} disabled={stopMut.isPending} className="btn-secondary text-xs py-1 px-2 disabled:opacity-60" title="Stop">
                 {stopMut.isPending ? <Loader2 className="w-3 h-3 animate-spin" /> : <Square className="w-3 h-3" />}
               </button>
-              <button onClick={onEdit} className="btn-ghost p-1.5" title="View settings (read-only while running)">
+              
+              {/* EYE BUTTON (Ausgegraut wenn man nicht der Besitzer/Admin ist) */}
+              <button onClick={onEdit} disabled={!isOwnerOrAdmin} className="btn-ghost p-1.5 disabled:opacity-40 disabled:cursor-not-allowed" title={!isOwnerOrAdmin ? 'No permission' : 'View settings (read-only while running)'}>
                 <Eye className="w-3.5 h-3.5" />
               </button>
             </>
           ) : (
             <>
-              <button onClick={() => startMut.mutate()} disabled={startMut.isPending || startMut.isSuccess || !serverOnline} className="btn-success text-xs py-1 px-2.5 disabled:opacity-60">
-                {startMut.isPending || startMut.isSuccess ? <Loader2 className="w-3 h-3 animate-spin" /> : <Play className="w-3 h-3" />}
+              <button onClick={() => startMut.mutate()} disabled={startMut.isPending || startMut.isSuccess || !serverOnline} className="btn-success flex-1 justify-center text-xs py-1.5 disabled:opacity-60">
+                <Play className="w-3.5 h-3.5" />
                 {startMut.isPending || startMut.isSuccess ? 'Starting…' : 'Start'}
               </button>
-              <button onClick={onEdit} disabled={!serverOnline} className="btn-ghost p-1.5 disabled:opacity-40 disabled:cursor-not-allowed" title={serverOnline ? 'Edit' : 'Server unavailable'}><Pencil className="w-3.5 h-3.5" /></button>
-              <button onClick={() => setDeleteConfirm(true)} disabled={!serverOnline} className="btn-ghost p-1.5 text-red-400 disabled:opacity-40 disabled:cursor-not-allowed" title={serverOnline ? undefined : 'Server unavailable'}>
+              
+              {/* EDIT BUTTON (Ausgegraut wenn man nicht der Besitzer/Admin ist) */}
+              <button onClick={onEdit} disabled={!serverOnline || !isOwnerOrAdmin} className="btn-ghost p-1.5 disabled:opacity-40 disabled:cursor-not-allowed" title={!isOwnerOrAdmin ? 'No permission' : serverOnline ? 'Edit' : 'Server unavailable'}>
+                <Pencil className="w-3.5 h-3.5" />
+              </button>
+              
+              {/* DELETE BUTTON (Ausgegraut wenn man nicht der Besitzer/Admin ist) */}
+              <button onClick={() => setDeleteConfirm(true)} disabled={!serverOnline || !isOwnerOrAdmin} className="btn-ghost p-1.5 text-red-400 disabled:opacity-40 disabled:cursor-not-allowed" title={!isOwnerOrAdmin ? 'No permission' : serverOnline ? undefined : 'Server unavailable'}>
                 <Trash2 className="w-3.5 h-3.5" />
               </button>
             </>
@@ -248,17 +321,26 @@ function VMRow({ vm, onEdit, groupColor, onStartError }: { vm: VM; onEdit: () =>
 
 // ─── Group Create/Edit Modal ───────────────────────────────────────────────────
 
-function GroupModal({ onSave, onClose, initial, hasRunningVMs = false }: {
-  onSave: (name: string, desc: string, color: string, networkEnabled: boolean) => void
+function GroupModal({ onSave, onClose, initial, hasRunningVMs = false, initialSharedWith }: {
+  onSave: (name: string, desc: string, color: string, networkEnabled: boolean, sharedWith: number[]) => void
   onClose: () => void
   initial?: { name: string; description?: string; color: string; network_enabled: boolean }
   hasRunningVMs?: boolean
+  initialSharedWith?: number[]
 }) {
   const [name, setName] = useState(initial?.name || '')
   const [desc, setDesc] = useState(initial?.description || '')
   const [color, setColor] = useState(initial?.color || '#6366f1')
   const [networkEnabled, setNetworkEnabled] = useState(initial?.network_enabled ?? false)
+  const [sharedWith, setSharedWith] = useState<number[]>(initialSharedWith || [])
+  const { currentUser } = useStore()
   const colors = ['#6366f1', '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#14b8a6']
+
+  const { data: users = [] } = useQuery({ 
+    queryKey: ['users'], 
+    queryFn: userApi.list,
+    enabled: !!currentUser?.is_admin 
+  })
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
@@ -320,10 +402,45 @@ function GroupModal({ onSave, onClose, initial, hasRunningVMs = false }: {
               </button>
             </div>
           </div>
+          <div className="border-t border-slate-200 dark:border-slate-700 pt-4">
+            <label className="label mb-2 block">Share with Users</label>
+            {!currentUser?.is_admin ? (
+              <p className="text-xs text-slate-500">Only administrators can share groups.</p>
+            ) : (
+              <div className="space-y-3">
+                <div className="flex flex-wrap gap-2">
+                  {users.filter(u => sharedWith.includes(u.id)).map(u => (
+                    <span key={u.id} className="inline-flex items-center gap-1.5 bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 px-2.5 py-1 rounded-md text-sm font-medium">
+                      {u.username}
+                      <button type="button" onClick={() => setSharedWith(sharedWith.filter(id => id !== u.id))} className="hover:text-red-500 focus:outline-none transition-colors">
+                        <X className="w-3.5 h-3.5" />
+                      </button>
+                    </span>
+                  ))}
+                  {sharedWith.length === 0 && <span className="text-sm text-slate-500 italic">Nobody shared with</span>}
+                </div>
+                
+                {users.filter(u => u.id !== currentUser.id && !sharedWith.includes(u.id)).length > 0 && (
+                  <select
+                    className="input w-full text-sm"
+                    value=""
+                    onChange={e => {
+                      if (e.target.value) setSharedWith([...sharedWith, parseInt(e.target.value)])
+                    }}
+                  >
+                    <option value="">+ Add another user...</option>
+                    {users.filter(u => u.id !== currentUser.id && !sharedWith.includes(u.id)).map(u => (
+                      <option key={u.id} value={u.id}>{u.username}</option>
+                    ))}
+                  </select>
+                )}
+              </div>
+            )}
+          </div>
         </div>
         <div className="flex gap-3 mt-6 justify-end">
           <button onClick={onClose} className="btn-secondary">Cancel</button>
-          <button onClick={() => { onSave(name, desc, color, networkEnabled); onClose() }} disabled={!name} className="btn-primary">Save</button>
+          <button onClick={() => { onSave(name, desc, color, networkEnabled, sharedWith); onClose() }} disabled={!name} className="btn-primary">Save</button>
         </div>
       </div>
     </div>
@@ -345,6 +462,12 @@ function GroupSection({ group, vms, view, onEditVM, collapsed, onToggle, cpuSpee
   onDeleteGroup: () => void
 }) {
   const groupColor = group.color
+  
+  const { currentUser } = useStore()
+  const isSharedWithMe = group.shared_with_user_ids?.includes(currentUser?.id || 0) || false;
+  const sharedCount = group.shared_with_user_ids?.length || 0;
+  const isGroupOwnerOrAdmin = currentUser?.is_admin || !isSharedWithMe;
+
   return (
     <div>
       <div className="flex items-center gap-2 mb-3">
@@ -357,26 +480,34 @@ function GroupSection({ group, vms, view, onEditVM, collapsed, onToggle, cpuSpee
               <Network className="w-3 h-3" />Networked
             </span>
           )}
+          <SharedBadge isSharedWithMe={isSharedWithMe} ownerName={undefined} sharedCount={sharedCount} asBadge={true} />
           <span className="ml-auto text-slate-400 flex-shrink-0">
             {collapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
           </span>
         </button>
-        <button onClick={onEditGroup} className="btn-ghost p-1.5 flex-shrink-0" title="Edit group">
+        
+        <button 
+          onClick={onEditGroup} 
+          disabled={!isGroupOwnerOrAdmin} 
+          className="btn-ghost p-1.5 flex-shrink-0 disabled:opacity-40 disabled:cursor-not-allowed" 
+          title={!isGroupOwnerOrAdmin ? 'No permission' : 'Edit group'}
+        >
           <Settings2 className="w-3.5 h-3.5" />
         </button>
         <button
           onClick={onDeleteGroup}
-          className="btn-ghost p-1.5 text-red-400 hover:text-red-600 flex-shrink-0"
-          title={group.has_running_vms ? 'Stop all VMs before deleting' : 'Delete group'}
-          disabled={group.has_running_vms}
+          disabled={group.has_running_vms || !isGroupOwnerOrAdmin}
+          className="btn-ghost p-1.5 text-red-400 hover:text-red-600 flex-shrink-0 disabled:opacity-40 disabled:cursor-not-allowed"
+          title={!isGroupOwnerOrAdmin ? 'No permission' : group.has_running_vms ? 'Stop all VMs before deleting' : 'Delete group'}
         >
           <Trash2 className="w-3.5 h-3.5" />
         </button>
       </div>
+      
       {!collapsed && (
         view === 'grid'
           ? <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-              {vms.map(vm => <VMCard key={vm.id} vm={vm} groupColor={groupColor} onEdit={() => onEditVM(vm)}cpuSpeeds={cpuSpeeds} onStartError={onStartError} />)}
+              {vms.map(vm => <VMCard key={vm.id} vm={vm} parentGroup={group} groupColor={groupColor} onEdit={() => onEditVM(vm)} cpuSpeeds={cpuSpeeds} onStartError={onStartError} />)}
             </div>
           : <div className="card overflow-hidden">
               <table className="w-full text-sm">
@@ -388,7 +519,7 @@ function GroupSection({ group, vms, view, onEditVM, collapsed, onToggle, cpuSpee
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
-                  {vms.map(vm => <VMRow key={vm.id} vm={vm} groupColor={groupColor} onEdit={() => onEditVM(vm)} onStartError={onStartError} />)}
+                  {vms.map(vm => <VMRow key={vm.id} vm={vm} parentGroup={group} groupColor={groupColor} onEdit={() => onEditVM(vm)} onStartError={onStartError} />)}
                 </tbody>
               </table>
             </div>
@@ -401,7 +532,7 @@ function GroupSection({ group, vms, view, onEditVM, collapsed, onToggle, cpuSpee
 
 export default function VMsPage() {
   const qc = useQueryClient()
-  const { addToast, authConfig, serverOnline, openTabs, updateTabGroupColor } = useStore()
+  const { currentUser, addToast, authConfig, serverOnline, openTabs, updateTabGroupColor } = useStore()
   const [view, setView] = useState<ViewMode>('grid')
   const [showCreateVM, setShowCreateVM] = useState(false)
   const [editVM, setEditVM] = useState<VM | null>(null)
@@ -413,7 +544,7 @@ export default function VMsPage() {
   const [deleteGroupConfirm, setDeleteGroupConfirm] = useState<VMGroup | null>(null)
 
   const { data: vms = [], isLoading } = useQuery({
-    queryKey: ['vms'],
+    queryKey: ['vms', currentUser?.id],
     queryFn: () => vmApi.list(),
     refetchInterval: 5000,
   })
@@ -445,31 +576,31 @@ export default function VMsPage() {
   })
 
   const { data: groups = [] as VMGroup[] } = useQuery({
-    queryKey: ['vm-groups'],
+    queryKey: ['vm-groups', currentUser?.id],
     queryFn: vmApi.listGroups,
   })
 
   const createVMMut = useMutation({
-    mutationFn: (data: { name: string; description?: string; group_id?: number; config: VMConfig }) => vmApi.create(data),
+    mutationFn: (data: { name: string; description?: string; group_id?: number; config: VMConfig; shared_with_user_ids?: number[] }) => vmApi.create(data),
     onSuccess: (vm) => { qc.invalidateQueries({ queryKey: ['vms'] }); addToast(`VM "${vm.name}" created`) },
     onError: (e: any) => addToast(e.message || 'Failed to create VM', 'error'),
   })
 
   const updateVMMut = useMutation({
-    mutationFn: ({ id, ...data }: { id: number; name?: string; description?: string; group_id?: number | null; config?: VMConfig }) =>
+    mutationFn: ({ id, ...data }: { id: number; name?: string; description?: string; group_id?: number | null; config?: VMConfig; shared_with_user_ids?: number[] }) =>
       vmApi.update(id, data),
     onSuccess: (vm) => { qc.invalidateQueries({ queryKey: ['vms'] }); addToast(`VM "${vm.name}" updated`) },
     onError: (e: any) => addToast(e.message || 'Failed to update VM', 'error'),
   })
 
   const createGroupMut = useMutation({
-    mutationFn: (data: { name: string; description?: string; color: string; network_enabled?: boolean }) => vmApi.createGroup(data),
+    mutationFn: (data: { name: string; description?: string; color: string; network_enabled?: boolean; shared_with_user_ids?: number[] }) => vmApi.createGroup(data),
     onSuccess: (g) => { qc.invalidateQueries({ queryKey: ['vm-groups'] }); addToast(`Group "${g.name}" created`) },
     onError: (e: any) => addToast(e.message || 'Failed to create group', 'error'),
   })
 
   const updateGroupMut = useMutation({
-    mutationFn: ({ id, ...data }: { id: number; name?: string; description?: string; color?: string; network_enabled?: boolean }) =>
+    mutationFn: ({ id, ...data }: { id: number; name?: string; description?: string; color?: string; network_enabled?: boolean; shared_with_user_ids?: number[] }) =>
       vmApi.updateGroup(id, data),
     onSuccess: (g) => { qc.invalidateQueries({ queryKey: ['vm-groups'] }); qc.invalidateQueries({ queryKey: ['vms'] }); addToast(`Group "${g.name}" updated`) },
     onError: (e: any) => addToast(e.message || 'Failed to update group', 'error'),
@@ -489,7 +620,7 @@ export default function VMsPage() {
   const grouped: Record<number, VM[]> = {}
   const ungrouped: VM[] = []
   filteredVMs.forEach(vm => {
-    if (vm.group_id) {
+    if (vm.group_id && groups.some(g => g.id === vm.group_id)) {
       if (!grouped[vm.group_id]) grouped[vm.group_id] = []
       grouped[vm.group_id].push(vm)
     } else {
@@ -545,17 +676,20 @@ export default function VMsPage() {
           <button onClick={() => setView('list')} className={clsx('btn-ghost p-2', view === 'list' && 'text-blue-600 dark:text-blue-400')}>
             <List className="w-4 h-4" />
           </button>
-          <button onClick={() => setShowCreateGroup(true)} disabled={!serverOnline} className="btn-secondary disabled:opacity-60" title={!serverOnline ? 'Server unavailable' : undefined}>
-            <FolderPlus className="w-4 h-4" />New Group
-          </button>
-          <button
-            disabled={!serverOnline}
-            onClick={() => atVMQuota ? addToast(`VM quota reached (${userStats!.max_vms} VMs). Delete a VM to create a new one.`, 'error') : setShowCreateVM(true)}
-            className={clsx('btn-primary', (atVMQuota || !serverOnline) && 'opacity-60')}
-            title={!serverOnline ? 'Server unavailable' : atVMQuota ? `Quota reached: ${userStats?.max_vms} VMs` : undefined}
-          >
-            <Plus className="w-4 h-4" />New VM
-          </button>
+        {(currentUser?.is_admin || currentUser?.can_manage_groups) && (
+            <button onClick={() => setShowCreateGroup(true)} disabled={!serverOnline} className="btn-secondary disabled:opacity-60" title={!serverOnline ? 'Server unavailable' : undefined}>
+              <FolderPlus className="w-4 h-4" />New Group
+            </button>
+          )}
+        {(currentUser?.is_admin || currentUser?.can_manage_vms) && (
+            <button
+              disabled={!serverOnline}
+              onClick={() => atVMQuota ? addToast(`VM quota reached.`, 'error') : setShowCreateVM(true)}
+              className={clsx('btn-primary', (atVMQuota || !serverOnline) && 'opacity-60')}
+            >
+              <Plus className="w-4 h-4" />New VM
+            </button>
+          )}
         </div>
       </div>
 
@@ -642,8 +776,8 @@ export default function VMsPage() {
           title="Create Virtual Machine"
           groups={groups}
           onClose={() => setShowCreateVM(false)}
-          onSave={async (name, desc, groupId, config) => {
-            await createVMMut.mutateAsync({ name, description: desc, group_id: groupId ?? undefined, config })
+          onSave={async (name, desc, groupId, config, sharedWith) => {
+            await createVMMut.mutateAsync({ name, description: desc, group_id: groupId ?? undefined, config, shared_with_user_ids: sharedWith })
           }}
         />
       )}
@@ -660,8 +794,9 @@ export default function VMsPage() {
           groups={groups}
           readOnly={editVM.status === 'running' || editVM.status === 'paused' || editVM.status === 'starting'}
           onClose={() => setEditVM(null)}
-          onSave={async (name, desc, groupId, config) => {
-            await updateVMMut.mutateAsync({ id: editVM.id, name, description: desc, group_id: groupId, config })
+          initialSharedWith={editVM.shared_with_user_ids}
+          onSave={async (name, desc, groupId, config, sharedWith) => {
+            await updateVMMut.mutateAsync({ id: editVM.id, name, description: desc, group_id: groupId, config, shared_with_user_ids: sharedWith })
           }}
         />
       )}
@@ -670,8 +805,8 @@ export default function VMsPage() {
       {showCreateGroup && (
         <GroupModal
           onClose={() => setShowCreateGroup(false)}
-          onSave={(name, desc, color, networkEnabled) =>
-            createGroupMut.mutate({ name, description: desc, color, network_enabled: networkEnabled })
+          onSave={(name, desc, color, networkEnabled, sharedWith) =>
+            createGroupMut.mutate({ name, description: desc, color, network_enabled: networkEnabled, shared_with_user_ids: sharedWith })
           }
         />
       )}
@@ -680,10 +815,11 @@ export default function VMsPage() {
       {editGroup && (
         <GroupModal
           initial={{ name: editGroup.name, description: editGroup.description, color: editGroup.color, network_enabled: editGroup.network_enabled }}
+          initialSharedWith={editGroup.shared_with_user_ids}
           hasRunningVMs={editGroup.has_running_vms}
           onClose={() => setEditGroup(null)}
-          onSave={(name, desc, color, networkEnabled) =>
-            updateGroupMut.mutate({ id: editGroup.id, name, description: desc, color, network_enabled: networkEnabled })
+          onSave={(name, desc, color, networkEnabled, sharedWith) =>
+            updateGroupMut.mutate({ id: editGroup.id, name, description: desc, color, network_enabled: networkEnabled, shared_with_user_ids: sharedWith })
           }
         />
       )}

--- a/frontend/src/pages/VMsPage.tsx
+++ b/frontend/src/pages/VMsPage.tsx
@@ -17,13 +17,17 @@ type ViewMode = 'grid' | 'list'
 function StatusBadge({ status }: { status: string }) {
   const map: Record<string, string> = {
     running: 'text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20',
-    stopped: 'text-slate-600 dark:text-slate-400 bg-slate-100 dark:bg-slate-800',
-    starting: 'text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20',
+    paused: 'text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20',
+    starting: 'text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20',
+    stopped: 'text-red-700 dark:text-red-400 bg-red-50 dark:bg-red-900/20',
     error: 'text-red-700 dark:text-red-400 bg-red-50 dark:bg-red-900/20',
   }
+  
+  const isAnimated = status === 'running' || status === 'paused' || status === 'starting'
+
   return (
     <span className={clsx('flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full font-medium', map[status] || map.stopped)}>
-      <span className={`status-${status} w-1.5 h-1.5`} />
+      <span className={clsx('w-1.5 h-1.5 rounded-full bg-current', isAnimated && 'animate-pulse')} />
       {status}
     </span>
   )
@@ -70,12 +74,24 @@ function VMCard({ vm, onEdit, groupColor, cpuSpeeds, onStartError }: { vm: VM; o
 
   const borderStyle = groupColor ? { borderTopColor: groupColor, borderTopWidth: 3 } : {}
 
+  const iconBgClass = !serverOnline ? 'bg-slate-100 dark:bg-slate-800'
+    : vm.status === 'running' ? 'bg-emerald-100 dark:bg-emerald-900/30'
+    : vm.status === 'paused' ? 'bg-amber-100 dark:bg-amber-900/30'
+    : vm.status === 'starting' ? 'bg-blue-100 dark:bg-blue-900/30'
+    : 'bg-red-100 dark:bg-red-900/30'
+
+  const iconTextClass = !serverOnline ? 'text-slate-400'
+    : vm.status === 'running' ? 'text-emerald-600 dark:text-emerald-400'
+    : vm.status === 'paused' ? 'text-amber-600 dark:text-amber-400'
+    : vm.status === 'starting' ? 'text-blue-600 dark:text-blue-400'
+    : 'text-red-600 dark:text-red-400'
+
   return (
     <div className="card-hover p-5 flex flex-col gap-4" style={borderStyle}>
       {/* Header */}
       <div className="flex items-start gap-3">
-        <div className={clsx('w-9 h-9 rounded-xl flex items-center justify-center flex-shrink-0', isRunning ? 'bg-emerald-100 dark:bg-emerald-900/30' : 'bg-slate-100 dark:bg-slate-800')}>
-          <Monitor className={clsx('w-4.5 h-4.5', isRunning ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-400')} />
+        <div className={clsx('w-9 h-9 rounded-xl flex items-center justify-center flex-shrink-0', iconBgClass)}>
+          <Monitor className={clsx('w-4.5 h-4.5', iconTextClass)} />
         </div>
         <div className="flex-1 min-w-0">
           <h3 className="font-semibold text-slate-900 dark:text-white text-sm truncate cursor-pointer hover:text-blue-600 dark:hover:text-blue-400" onClick={() => openVMTab({ vmId: vm.id, vmUuid: vm.uuid, vmName: vm.name, status: vm.status, group_color: vm.group_color })}>{vm.name}</h3>
@@ -115,7 +131,12 @@ function VMCard({ vm, onEdit, groupColor, cpuSpeeds, onStartError }: { vm: VM; o
             <button onClick={() => openVMTab({ vmId: vm.id, vmUuid: vm.uuid, vmName: vm.name, status: vm.status, group_color: vm.group_color })} className="btn-primary flex-1 justify-center text-xs py-1.5">
               <Monitor className="w-3.5 h-3.5" />Console
             </button>
-            <button onClick={() => stopMut.mutate()} disabled={stopMut.isPending} className="btn-secondary p-2" title="Stop">
+            <button 
+              onClick={() => stopMut.mutate()} 
+              disabled={stopMut.isPending} 
+              className="btn-secondary p-2 hover:!bg-red-100 hover:!text-red-600 hover:!border-red-200 dark:hover:!bg-red-900/30 dark:hover:!text-red-400 dark:hover:!border-red-800 transition-colors" 
+              title="Stop"
+            >
               <Square className="w-3.5 h-3.5" />
             </button>
             <button onClick={onEdit} className="btn-ghost p-2" title="View settings (read-only while running)">
@@ -185,13 +206,25 @@ function VMRow({ vm, onEdit, groupColor, onStartError }: { vm: VM; onEdit: () =>
 
   const rowStyle = groupColor ? { borderLeft: `3px solid ${groupColor}` } : {}
 
+  const iconBgClass = !serverOnline ? 'bg-slate-100 dark:bg-slate-800'
+    : vm.status === 'running' ? 'bg-emerald-100 dark:bg-emerald-900/30'
+    : vm.status === 'paused' ? 'bg-amber-100 dark:bg-amber-900/30'
+    : vm.status === 'starting' ? 'bg-blue-100 dark:bg-blue-900/30'
+    : 'bg-red-100 dark:bg-red-900/30'
+
+  const iconTextClass = !serverOnline ? 'text-slate-400'
+    : vm.status === 'running' ? 'text-emerald-600 dark:text-emerald-400'
+    : vm.status === 'paused' ? 'text-amber-600 dark:text-amber-400'
+    : vm.status === 'starting' ? 'text-blue-600 dark:text-blue-400'
+    : 'text-red-600 dark:text-red-400'
+
   return (
     <>
     <tr className="hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors" style={rowStyle}>
       <td className="px-5 py-3">
         <div className="flex items-center gap-3">
-          <div className={clsx('w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0', isRunning ? 'bg-emerald-100 dark:bg-emerald-900/30' : 'bg-slate-100 dark:bg-slate-800')}>
-            <Monitor className={clsx('w-3.5 h-3.5', isRunning ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-400')} />
+          <div className={clsx('w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0', iconBgClass)}>
+            <Monitor className={clsx('w-3.5 h-3.5', iconTextClass)} />
           </div>
           <div className="min-w-0">
             <p className="text-sm font-medium text-slate-900 dark:text-white truncate cursor-pointer hover:text-blue-600 dark:hover:text-blue-400" onClick={() => openVMTab({ vmId: vm.id, vmUuid: vm.uuid, vmName: vm.name, status: vm.status, group_color: vm.group_color })}>{vm.name}</p>
@@ -211,7 +244,11 @@ function VMRow({ vm, onEdit, groupColor, onStartError }: { vm: VM; onEdit: () =>
               <button onClick={() => openVMTab({ vmId: vm.id, vmUuid: vm.uuid, vmName: vm.name, status: vm.status, group_color: vm.group_color })} className="btn-primary text-xs py-1 px-2.5">
                 <Monitor className="w-3 h-3" />Console
               </button>
-              <button onClick={() => stopMut.mutate()} disabled={stopMut.isPending} className="btn-secondary text-xs py-1 px-2 disabled:opacity-60">
+              <button 
+                onClick={() => stopMut.mutate()} 
+                disabled={stopMut.isPending} 
+                className="btn-secondary text-xs py-1 px-2 disabled:opacity-60 hover:!bg-red-100 hover:!text-red-600 hover:!border-red-200 dark:hover:!bg-red-900/30 dark:hover:!text-red-400 dark:hover:!border-red-800 transition-colors"
+              >
                 {stopMut.isPending ? <Loader2 className="w-3 h-3 animate-spin" /> : <Square className="w-3 h-3" />}
               </button>
               <button onClick={onEdit} className="btn-ghost p-1.5" title="View settings (read-only while running)">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,6 +12,10 @@ export interface User {
   vm_count: number
   disk_usage_bytes: number
   is_bootstrap?: boolean
+  can_manage_vms?: boolean;
+  can_manage_groups?: boolean;
+  can_access_library?: boolean;
+  can_upload_images?: boolean;
 }
 
 export interface VMGroup {
@@ -24,6 +28,7 @@ export interface VMGroup {
   created_at: string
   vm_count: number
   has_running_vms: boolean
+  shared_with_user_ids?: number[];
 }
 
 export interface VMConfig {
@@ -223,6 +228,9 @@ export interface VM {
   owner_username?: string
   group_name?: string
   group_color?: string
+  locked_by_user_id?: number | null;
+  locked_by_username?: string | null;
+  shared_with_user_ids?: number[];
 }
 
 export interface SystemStats {


### PR DESCRIPTION
**Description:**
This PR introduces a robust, privacy-first access control and sharing system for Virtual Machines and VM Groups. It completely overhauls how permissions are handled, inherited, visualized, and enforced across both the frontend and backend, while also improving UI consistency and fixing state-lock bugs.
Additionally, a Permission system for users is being introduced.

<img width="470" height="675" alt="Bildschirmfoto 2026-03-22 um 15 49 12" src="https://github.com/user-attachments/assets/48ffc48e-a1ca-42d5-b1d7-c21758f4dc06" />

_1. Privacy-First Architecture_
- Strict Isolation: All VMs and Groups are strictly private by default.
- Visibility: Administrators and regular users can only see and interact with VMs / Groups that they actively own or that have been explicitly shared with them. This respects user privacy and declutters the dashboard.

_2. Granular Sharing & Permission Inheritance_
- Tag-Based UI: Introduced a modern, chip / tag-based multiselect UI in the VM and Group settings to easily add or remove access for specific users.

<img width="690" height="123" alt="Screenshot 2026-03-22 um 15 41 57" src="https://github.com/user-attachments/assets/dae6d7fa-2806-482f-af09-31eca32bf67b" />

<img width="462" height="360" alt="Screenshot 2026-03-22 um 15 42 20" src="https://github.com/user-attachments/assets/1e5675de-b979-4c86-b339-b7f1f3cd084e" />

- Group Inheritance: Sharing a VM Group now automatically cascades access rights to all VMs contained within that group. Shared Groups or VMs cannot be edited by the users that it was shared with. (I am thinking already of a feature to duplicate / Clone a VM (if allowed) to a users own space and therefore use the own quota. That way an editing is possible).

<img width="442" height="256" alt="Screenshot 2026-03-22 um 15 49 31" src="https://github.com/user-attachments/assets/85775fde-3952-4177-a673-a7a914ad3d68" />

- Conflict Prevention: If a VM is inside a shared group, its individual sharing controls are locked (read-only) in the UI. A clear warning message explains that permissions are currently inherited from the parent group, preventing complex permission overlaps.

<img width="686" height="127" alt="Screenshot 2026-03-22 um 16 05 14" src="https://github.com/user-attachments/assets/671d8fce-fff5-4f15-9d1d-587bc13bbc85" />

- The Quota for VMs is being used only for the Creator of the VM. So as an example: If I create a VM and share it with my users, they do not lose a VM quota place. I decided that this is the easiest way to implement this feature, as else you need to calculate the usages. And what if I a user does not want to have a VM?

_3. UI & UX Consistency improvements_
- Visual Sharing Indicators: Added elegant Shared badges across the Grid View, List View, and Group Headers.

<img width="655" height="581" alt="Screenshot 2026-03-22 um 15 47 30" src="https://github.com/user-attachments/assets/b540a1fe-b366-4bd1-968a-2cb85ee41f1a" />

- The badges use intuitive icons (an up-arrow if shared by the current user, a down-arrow if shared with the current user).
- Hover tooltips provide quick context (e.g., "Shared with 2 users" or "Shared from Admin").

<img width="194" height="126" alt="Bildschirmfoto 2026-03-22 um 15 42 38" src="https://github.com/user-attachments/assets/343e90e1-82d1-4c3f-b44a-828d248376ca" />
<img width="176" height="95" alt="Bildschirmfoto 2026-03-22 um 15 43 37" src="https://github.com/user-attachments/assets/3d5db920-af27-45b9-9a7c-bfc7f77bb3c0" />

- Disabled vs. Hidden Buttons: Action buttons (Edit, Delete, Console) are no longer completely hidden when a user lacks permissions. Instead, they remain in their expected positions but are visually disabled (greyed out) with tooltips explaining the lack of access. This preserves layout consistency and prevents UI jumping.

<img width="1264" height="275" alt="Bildschirmfoto 2026-03-22 um 15 43 58" src="https://github.com/user-attachments/assets/9e9b7d82-43f8-4e15-a137-4a0bc84c4ae4" />


_4. VM State & Lock Management (Self-Healing)_
- Lock Bug Fix: Fixed an issue where VMs could remain permanently stuck as "Locked by [User]" if the 86Box process crashed or failed during startup. This was bugging me all the time with my test scenarios.
- Self-Healing Backend: The backend now automatically clears the locked_by_user_id database field whenever a VM's state returns to "stopped".
- Clearer UI Feedback: If a VM is currently locked / started by someone else, other users now see a clear orange "🔒 In use by [User]" indicator. Admins retain a visually distinct override button. Basic logic is: whoever starts the VM, locks the VM.

<img width="315" height="226" alt="Bildschirmfoto 2026-03-22 um 15 43 24" src="https://github.com/user-attachments/assets/3327c81f-16e4-4eec-b984-2870131bb60e" />
<img width="486" height="261" alt="Bildschirmfoto 2026-03-22 um 15 45 02" src="https://github.com/user-attachments/assets/6dd8f699-3681-47a6-9793-98e77ab978c2" />

_5. Technical / Under the hood:_
- Added the `user_group_access` association table in SQLAlchemy to persist group sharing. The database change will be inserted, no need to rebuild the database (and thus delete settings, VM IDs, etc.)
- Updated React Query cache keys (e.g., ['vms', currentUser.id]) to ensure strict state isolation between different users on the same browser session.
- Refactored VMCard, VMRow, and GroupSection components to handle prop-drilling for group inheritance efficiently.

Once this PR was merged, I highly recommend a beta testing, as I most probably did not caught all scenarios for using this feature. It worked fine for me and my extended testing, but maybe somebody else will find open bugs that I did not think of.

(Closes #15)

