### PR TITLE
fix: use correct 86Box config key cdrom_{n}_fn for CD-ROM image path

### DIFF
--- a/backend/app/routers/vms.py
+++ b/backend/app/routers/vms.py
@@ -706,7 +706,7 @@ def _write_86box_config(vm: VM, vm_dir: str, config_override: dict | None = None
                 opt(f"cdrom_{n}_ide_channel", channel)
             fn = cfg.get(f"cdrom_{n}_fn", "")
             if fn:
-                opt(f"cdrom_{n}_image_path", fn)
+                opt(f"cdrom_{n}_fn", fn)
 
     # ── [Ports (COM & LPT)] ───────────────────────────────────────────────────
     section("Ports (COM & LPT)")


### PR DESCRIPTION
## Summary

Fixes #19.

### Bug

In `_write_86box_config()`, the CD-ROM image path was written to the config using the key `cdrom_{n}_image_path`:

```python
opt(f"cdrom_{n}_image_path", fn)
```

86Box expects the key `cdrom_{n}_fn` (e.g. `cdrom_01_fn`). Using the wrong key means 86Box silently ignores it, so CD-ROM images are never mounted even though the UI shows the correct configuration.

### Fix

Changed the key to the correct value:

```python
opt(f"cdrom_{n}_fn", fn)
```

This is a one-line fix. The floppy drive path (`fdd_{n}_fn`) already used the correct key and is unaffected.